### PR TITLE
Close/reconnect the connection when Redis protocol is corrupted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-redis</artifactId>
+            <version>${netty-version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/src/test/java/com/lambdaworks/redis/protocol/CorruptedProtocolTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/CorruptedProtocolTest.java
@@ -1,0 +1,83 @@
+package com.lambdaworks.redis.protocol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.lambdaworks.redis.ClientOptions;
+import com.lambdaworks.redis.RedisClient;
+import com.lambdaworks.redis.RedisException;
+import com.lambdaworks.redis.RedisURI.Builder;
+import com.lambdaworks.redis.api.sync.RedisCommands;
+
+public class CorruptedProtocolTest {
+
+    private MockRedisServer mockRedisServer;
+
+    private RedisClient redisClient;
+
+    private RedisCommands<String, String> connection;
+
+    @Before
+    public void before() {
+
+        mockRedisServer = new MockRedisServer();
+        mockRedisServer.startServer();
+        redisClient = RedisClient.create(Builder.redis("localhost", mockRedisServer.port()).build());
+        redisClient.setOptions(ClientOptions.builder().autoReconnect(true)
+                .disconnectedBehavior(ClientOptions.DisconnectedBehavior.ACCEPT_COMMANDS).build());
+        connection = redisClient.connect().sync();
+    }
+
+    @After
+    public void after() {
+
+        redisClient.shutdown();
+        mockRedisServer.close();
+    }
+
+    @Test
+    public void normalGetTest() {
+
+        mockRedisServer.setResponses(
+                "$-1\r\n",
+                "$0\r\n\r\n",
+                "$6\r\nfoobar\r\n");
+
+        assertNull(connection.get("test1"));
+        assertEquals("", connection.get("test2"));
+        assertEquals("foobar", connection.get("test3"));
+    }
+
+    @Test(expected = RedisException.class)
+    public void badProtocolFirstTimeTest() {
+
+        mockRedisServer.setResponses("\r\nfoobar\r\n"); // simulate a corrupted case.
+
+        connection.get("test4");
+    }
+
+    @Test
+    public void badProtocolAndNextRequestTest() throws Exception {
+
+        mockRedisServer.setResponses(
+                "$3\r\n123\r\n",
+                "\r\nfoobar\r\n"); // simulate a corrupted case.
+
+        assertEquals("123", connection.get("test5"));
+        try {
+            connection.get("test6");
+            fail();
+        } catch (RedisException e) {
+            // expected.
+        }
+
+        mockRedisServer.setResponses("$6\r\nfoobar\r\n");
+
+        assertEquals("foobar", connection.get("test7"));
+    }
+}

--- a/src/test/java/com/lambdaworks/redis/protocol/MockRedisServer.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/MockRedisServer.java
@@ -1,0 +1,132 @@
+package com.lambdaworks.redis.protocol;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.redis.RedisArrayAggregator;
+import io.netty.handler.codec.redis.RedisBulkStringAggregator;
+import io.netty.handler.codec.redis.RedisDecoder;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class MockRedisServer implements Closeable {
+
+    protected static final InternalLogger logger = InternalLoggerFactory.getInstance(MockRedisServer.class);
+
+    private int port;
+    private EventLoopGroup eventLoopGroup;
+    private ChannelFuture closeFuture;
+
+    private Iterator<byte[]> mockResponseIterator;
+
+    public int port() {
+        return port;
+    }
+
+    @Override
+    public void close() {
+
+        try {
+            eventLoopGroup.shutdownGracefully().sync();
+            logger.info("MockRedisServer: closed: port={}", port);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void sync() throws InterruptedException {
+
+        closeFuture.sync();
+    }
+
+    public void setResponses(String... mockResponses) {
+
+        mockResponseIterator = Arrays.stream(mockResponses)
+                                     .map(s -> s.getBytes(StandardCharsets.UTF_8))
+                                     .iterator();
+    }
+
+    public void setResponses(byte[]... mockResponses) {
+
+        mockResponseIterator = Arrays.stream(mockResponses).iterator();
+    }
+
+    public void startServer() {
+
+        this.mockResponseIterator = Collections.emptyIterator();
+        this.eventLoopGroup = new NioEventLoopGroup(1);
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(eventLoopGroup)
+         .channel(NioServerSocketChannel.class)
+         .option(ChannelOption.SO_BACKLOG, 100)
+         .handler(new LoggingHandler(LogLevel.INFO))
+         .childHandler(new ChannelInitializer<SocketChannel>() {
+             @Override
+             public void initChannel(SocketChannel ch) throws Exception {
+                 ChannelPipeline p = ch.pipeline();
+                 p.addLast(new RedisDecoder());
+                 p.addLast(new RedisBulkStringAggregator());
+                 p.addLast(new RedisArrayAggregator());
+                 //p.addLast(new RedisEncoder()); // This is correct encoder, so we cannot make wrong responses.
+                 p.addLast(new MockRedisServerHandler());
+             }
+         });
+
+        try {
+            // Start the server.
+            ChannelFuture f = b.bind("localhost", 0).sync();
+
+            // store ephemeral listen port
+            this.port = ((InetSocketAddress) f.channel().localAddress()).getPort();
+
+            // and set closeFuture.
+            this.closeFuture = f.channel().closeFuture();
+
+            logger.info("MockRedisServer: started: port={}", port);
+        } catch (InterruptedException e) {
+            logger.error("MockRedisServer: failed", e);
+            throw new RuntimeException(e);
+        } catch (Throwable e) {
+            logger.error("MockRedisServer: failed", e);
+            throw e;
+        }
+    }
+
+    private class MockRedisServerHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            if (!mockResponseIterator.hasNext()) {
+                throw new NoSuchElementException("No more mock responses. Set your responses first.");
+            }
+            final byte[] currentResponse = mockResponseIterator.next();
+            final ByteBuf buf = ctx.alloc().ioBuffer(currentResponse.length);
+            buf.writeBytes(currentResponse);
+            ctx.writeAndFlush(buf);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            logger.warn("exceptionCaught", cause);
+            ctx.close();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

When RESP(REdis Serialization Protocol) is corrupted, users should disconnect and reconnect to target Redis(or proxy) server. In that case, current Lettuce sent next requests based on corrupted Redis State Machine. I fixed it and added a test.

And, this PR is suitable on `4.3.x` branch too.