### PR TITLE
Fix FastCountingDeque not recording correct size.

### DIFF
--- a/src/main/java/com/lambdaworks/redis/internal/FastCountingDeque.java
+++ b/src/main/java/com/lambdaworks/redis/internal/FastCountingDeque.java
@@ -294,11 +294,11 @@ public class FastCountingDeque<E> extends ForwardingDeque<E> implements Deque<E>
     }
 
     protected void increment() {
-        assert UPDATER.incrementAndGet(this) > 0;
+        UPDATER.incrementAndGet(this);
     }
 
     protected void decrement() {
-        assert UPDATER.decrementAndGet(this) >= 0;
+        UPDATER.decrementAndGet(this);
     }
 
     private static class UnmodifiableIterator<E> implements Iterator<E> {


### PR DESCRIPTION
Remove assert to avoid counting not works at production env.

--
I'm still investigating the issue of https://github.com/lettuce-io/lettuce-core/issues/466 . Because we recently have same problem again, and found my setting of requestQueueSize not works.
