### PR TITLE
[WIP] Fix ConnectionWatchdog won't reconnect problem

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/ConnectionWatchdog.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/ConnectionWatchdog.java
@@ -214,7 +214,7 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter implements 
             int timeout = (int) reconnectDelay.getTimeUnit().toMillis(reconnectDelay.createDelay(attempt));
             logger.debug("Reconnect attempt {}, delay {}ms", attempt, timeout);
 
-            this.reconnectScheduleTimeout = timer.newTimeout(it -> {
+            Timeout reconnectScheduleTimeout = timer.newTimeout(it -> {
 
                 if (!isEventLoopGroupActive()) {
                     logger.debug("isEventLoopGroupActive() == false");
@@ -226,6 +226,9 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter implements 
                     return null;
                 });
             }, timeout, TimeUnit.MILLISECONDS);
+            if (!reconnectScheduleTimeout.isExpired()) {
+                this.reconnectScheduleTimeout = reconnectScheduleTimeout;
+            }
         } else {
             logger.debug("{} Skipping scheduleReconnect() because I have an active channel", logPrefix());
         }


### PR DESCRIPTION
Apply this change, we can avoid race condition of checking if reconnecting.

--
To fix issue #466 , I try to run in debug mode and force `System.gc` at last line of `HashedWheelTimer.newTimeout`. And it looks like can make `reconnectScheduleTimeout.isExpired() == true` after assignment. Still find way to constantly reproduce the problem.(Or maybe it's not good to using timer#newTimeout's result as flag, maybe just create boolean flag one line before `timer.newTimeout` and set flag to false at reconnect, then use that flag to check if there is ongoing reconnecting?)