### PR TITLE
Added API to delete a single key without creating an Array or Iterable

### DIFF
--- a/src/main/java/com/lambdaworks/redis/AbstractRedisAsyncCommands.java
+++ b/src/main/java/com/lambdaworks/redis/AbstractRedisAsyncCommands.java
@@ -285,6 +285,11 @@ public abstract class AbstractRedisAsyncCommands<K, V>
     }
 
     @Override
+    public RedisFuture<Long> del(K key) {
+        return dispatch(commandBuilder.del(key));
+    }
+
+    @Override
     public RedisFuture<Long> del(K... keys) {
         return dispatch(commandBuilder.del(keys));
     }

--- a/src/main/java/com/lambdaworks/redis/AbstractRedisReactiveCommands.java
+++ b/src/main/java/com/lambdaworks/redis/AbstractRedisReactiveCommands.java
@@ -277,6 +277,11 @@ public abstract class AbstractRedisReactiveCommands<K, V> implements RedisHashRe
     }
 
     @Override
+    public Observable<Long> del(K key) {
+        return createObservable(() -> commandBuilder.del(key));
+    }
+
+    @Override
     public Observable<Long> del(K... keys) {
         return createObservable(() -> commandBuilder.del(keys));
     }

--- a/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
+++ b/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
@@ -340,6 +340,13 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(DECRBY, new IntegerOutput<K, V>(codec), args);
     }
 
+    public Command<K, V, Long> del(K key) {
+        notNullKey(key);
+
+        CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
+        return createCommand(DEL, new IntegerOutput<K, V>(codec), args);
+    }
+
     public Command<K, V, Long> del(K... keys) {
         notEmpty(keys);
 

--- a/src/main/java/com/lambdaworks/redis/RedisKeysAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisKeysAsyncConnection.java
@@ -34,6 +34,14 @@ import com.lambdaworks.redis.output.ValueStreamingChannel;
 public interface RedisKeysAsyncConnection<K, V> {
 
     /**
+     * Delete one key.
+     *
+     * @param key the key
+     * @return RedisFuture&lt;Long&gt; integer-reply The number of keys that were removed.
+     */
+    RedisFuture<Long> del(K key);
+
+    /**
      * Delete one or more keys.
      *
      * @param keys the keys

--- a/src/main/java/com/lambdaworks/redis/api/async/RedisKeyAsyncCommands.java
+++ b/src/main/java/com/lambdaworks/redis/api/async/RedisKeyAsyncCommands.java
@@ -34,6 +34,14 @@ import com.lambdaworks.redis.output.ValueStreamingChannel;
 public interface RedisKeyAsyncCommands<K, V> {
 
     /**
+     * Delete one key.
+     *
+     * @param key the key
+     * @return Long integer-reply The number of keys that were removed.
+     */
+    RedisFuture<Long> del(K key);
+
+    /**
      * Delete one or more keys.
      *
      * @param keys the keys

--- a/src/main/java/com/lambdaworks/redis/api/rx/RedisKeyReactiveCommands.java
+++ b/src/main/java/com/lambdaworks/redis/api/rx/RedisKeyReactiveCommands.java
@@ -35,6 +35,14 @@ import rx.Observable;
 public interface RedisKeyReactiveCommands<K, V> {
 
     /**
+     * Delete one key.
+     *
+     * @param key the key
+     * @return Long integer-reply The number of keys that were removed.
+     */
+    Observable<Long> del(K key);
+
+    /**
      * Delete one or more keys.
      *
      * @param keys the keys


### PR DESCRIPTION
We are using byte[] as keys, and Findbugs just made me aware that:

`This code passes a primitive array to a function that takes a variable number of object arguments. This creates an array of length one to hold the primitive array and passes it to the function.`

when we invoke: com.lambdaworks.redis.cluster.api.async.RedisClusterAsyncCommands.del(Object[])

so while it currently works, I think there should be an API in lettuce that supports a single key delete without the need to create a temp array or iterable.