### PR TITLE
print what read when IllegalStateException happen.

### DIFF
--- a/src/main/java/com/lambdaworks/redis/output/CommandOutput.java
+++ b/src/main/java/com/lambdaworks/redis/output/CommandOutput.java
@@ -62,7 +62,7 @@ public abstract class CommandOutput<K, V, T> {
      * @param bytes The command output, or null.
      */
     public void set(ByteBuffer bytes) {
-        throw new IllegalStateException();
+        throw new IllegalStateException(new String(bytes.array()));
     }
 
     /**
@@ -72,7 +72,7 @@ public abstract class CommandOutput<K, V, T> {
      * @param integer The command output.
      */
     public void set(long integer) {
-        throw new IllegalStateException();
+        throw new IllegalStateException(String.valueOf(integer));
     }
 
     /**


### PR DESCRIPTION
I got a IllegalStateException thrown at CommandOutput.set(long), and I want to know what exactly the value is . 
