### PR TITLE
Add socks 4/5 proxy support for lettuce-core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
 
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <classifier>linux-x86_64</classifier>
             <optional>true</optional>

--- a/src/main/java/com/lambdaworks/redis/SocketOptions.java
+++ b/src/main/java/com/lambdaworks/redis/SocketOptions.java
@@ -32,18 +32,20 @@ public class SocketOptions {
 
     public static final boolean DEFAULT_SO_KEEPALIVE = false;
     public static final boolean DEFAULT_SO_NO_DELAY = false;
+    public static final SocksProxyOptions DEFAULT_SOCKS_PROXY = null;
 
     private final long connectTimeout;
     private final TimeUnit connectTimeoutUnit;
     private final boolean keepAlive;
     private final boolean tcpNoDelay;
+    private final SocksProxyOptions socksProxyOptions;
 
     protected SocketOptions(Builder builder) {
-
         this.connectTimeout = builder.connectTimeout;
         this.connectTimeoutUnit = builder.connectTimeoutUnit;
         this.keepAlive = builder.keepAlive;
         this.tcpNoDelay = builder.tcpNoDelay;
+        this.socksProxyOptions = builder.socksProxyOptions;
     }
 
     protected SocketOptions(SocketOptions original) {
@@ -51,6 +53,7 @@ public class SocketOptions {
         this.connectTimeoutUnit = original.getConnectTimeoutUnit();
         this.keepAlive = original.isKeepAlive();
         this.tcpNoDelay = original.isTcpNoDelay();
+        this.socksProxyOptions = original.getSocksProxyOptions();
     }
 
     /**
@@ -90,6 +93,7 @@ public class SocketOptions {
         private TimeUnit connectTimeoutUnit = DEFAULT_CONNECT_TIMEOUT_UNIT;
         private boolean keepAlive = DEFAULT_SO_KEEPALIVE;
         private boolean tcpNoDelay = DEFAULT_SO_NO_DELAY;
+        private SocksProxyOptions socksProxyOptions = DEFAULT_SOCKS_PROXY;
 
         private Builder() {
         }
@@ -140,6 +144,18 @@ public class SocketOptions {
         }
 
         /**
+         * Sets socks proxy.
+         *
+         * @param socksProxyOptions options for socks proxy.
+         * @return {@code this}
+         */
+        public Builder socksProxy(SocksProxyOptions socksProxyOptions) {
+
+            this.socksProxyOptions = socksProxyOptions;
+            return this;
+        }
+
+        /**
          * Create a new instance of {@link SocketOptions}
          *
          * @return new instance of {@link SocketOptions}
@@ -185,5 +201,14 @@ public class SocketOptions {
      */
     public boolean isTcpNoDelay() {
         return tcpNoDelay;
+    }
+
+    /**
+     * Returns socks proxy options.
+     *
+     * @return socks proxy options.
+     */
+    public SocksProxyOptions getSocksProxyOptions() {
+        return socksProxyOptions;
     }
 }

--- a/src/main/java/com/lambdaworks/redis/SocksProxyOptions.java
+++ b/src/main/java/com/lambdaworks/redis/SocksProxyOptions.java
@@ -1,0 +1,162 @@
+package com.lambdaworks.redis;
+
+/**
+ * Options to configure a SOCKS 4/5 proxy.
+ *
+ * @author Yiding He
+ */
+public class SocksProxyOptions {
+
+    public static final int SOCKS_VERSION_4 = 4;
+
+    public static final int SOCKS_VERSION_5 = 5;
+
+    public static final int DEFAULT_SOCKS_VERSION = SOCKS_VERSION_5;
+
+    private final String host;
+
+    private final int port;
+
+    private final String username;
+
+    private final String password;
+
+    private final int socksVersion;
+
+    protected SocksProxyOptions(Builder builder) {
+        this.host = builder.host;
+        this.port = builder.port;
+        this.username = builder.username;
+        this.password = builder.password;
+        this.socksVersion = builder.socksVersion;
+    }
+
+    protected SocksProxyOptions(SocksProxyOptions original) {
+        this.host = original.getHost();
+        this.port = original.getPort();
+        this.username = original.getUsername();
+        this.password = original.getPassword();
+        this.socksVersion = original.getSocksVersion();
+    }
+
+    /**
+     * Returns a new {@link Builder} to construct {@link SocksProxyOptions}.
+     *
+     * @param host host name or ip address of proxy server.
+     * @param port port of proxy server.
+     * @return a new {@link Builder} to construct {@link SocksProxyOptions}.
+     */
+    public static Builder builder(String host, int port) {
+        return new Builder(host, port);
+    }
+
+    public static class Builder {
+
+        private String host;
+
+        private int port;
+
+        private String username;
+
+        private String password;
+
+        private int socksVersion = DEFAULT_SOCKS_VERSION;
+
+        private Builder(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+        /**
+         * Set version number of socks proxy.
+         *
+         * @param socksVersion version number of socks proxy.
+         * @return {@code this}
+         */
+        public Builder socksVersion(int socksVersion) {
+            if (socksVersion != SOCKS_VERSION_4 && socksVersion != SOCKS_VERSION_5) {
+                throw new IllegalArgumentException("socks version should be 4 or 5.");
+            }
+            this.socksVersion = socksVersion;
+            return this;
+        }
+
+        /**
+         * Set password of socks proxy.
+         *
+         * @param password password of socks proxy.
+         * @return {@code this}
+         */
+        public Builder password(String password) {
+
+            this.password = password;
+            return this;
+        }
+
+        /**
+         * Set username of socks proxy.
+         *
+         * @param username username of socks proxy.
+         * @return {@code this}
+         */
+        public Builder username(String username) {
+
+            this.username = username;
+            return this;
+        }
+
+        /**
+         * Create a new instance of {@link SocksProxyOptions}
+         *
+         * @return new instance of {@link SocksProxyOptions}
+         */
+        public SocksProxyOptions build() {
+            return new SocksProxyOptions(this);
+        }
+    }
+
+    /**
+     * Get host name or ip address of proxy server.
+     *
+     * @return host name or ip address of proxy server.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Get port of proxy server.
+     *
+     * @return port of proxy server.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Get username of socks proxy.
+     *
+     * @return username of socks proxy.
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Get password of socks proxy. Socks proxy version 4 don't use a password.
+     *
+     * @return password of socks proxy.
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Get socks version of proxy server.
+     *
+     * @return socks version of proxy server.
+     */
+    public int getSocksVersion() {
+        return socksVersion;
+    }
+}

--- a/src/test/java/com/lambdaworks/examples/ConnectToRedisViaProxy.java
+++ b/src/test/java/com/lambdaworks/examples/ConnectToRedisViaProxy.java
@@ -1,0 +1,40 @@
+package com.lambdaworks.examples;
+
+import com.lambdaworks.redis.ClientOptions;
+import com.lambdaworks.redis.RedisClient;
+import com.lambdaworks.redis.SocketOptions;
+import com.lambdaworks.redis.SocksProxyOptions;
+import com.lambdaworks.redis.api.StatefulRedisConnection;
+
+/**
+ * @author yidin
+ */
+public class ConnectToRedisViaProxy {
+
+    public static void main(String[] args) {
+
+        String proxyHost = "127.0.0.1";
+        int proxyPort = 2346;
+
+        SocksProxyOptions socksProxyOptions = SocksProxyOptions
+                .builder(proxyHost, proxyPort)
+                .socksVersion(SocksProxyOptions.SOCKS_VERSION_5)
+                .build();
+
+        SocketOptions socketOptions = SocketOptions.builder().socksProxy(socksProxyOptions).build();
+        ClientOptions clientOptions = ClientOptions.builder().socketOptions(socketOptions).build();
+
+        // Syntax: redis://[password@]host[:port][/databaseNumber]
+        // Assume redis server below is behind a socks proxy
+        RedisClient redisClient = RedisClient.create("redis://10.10.22.124:6379/0");
+        redisClient.setOptions(clientOptions);
+
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+
+        System.out.println("Connected to Redis");
+
+        connection.close();
+        redisClient.shutdown();
+    }
+
+}


### PR DESCRIPTION
Hi, I added socks proxy support for `lettuce-core` using `netty-handler-proxy`. 

I created `SocksProxyOptions` class and assigned it as member of `SocketOptions` class. 

There is also a test case `com.lambdaworks.examples.ConnectToRedisViaProxy` which is for now only tested on SOCKS5 proxy.

Please let me know if there is any problem in this PR and I'll try to fix it.

Make sure that:

- [x]  You have read the contribution guidelines.
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.