### PR TITLE
Fix IllegalArgumentException("hostname can't be null")

### DIFF
--- a/src/main/java/com/lambdaworks/redis/RedisClient.java
+++ b/src/main/java/com/lambdaworks/redis/RedisClient.java
@@ -780,7 +780,7 @@ public class RedisClient extends AbstractRedisClient {
                 connectionBuilder.socketAddressSupplier(getSocketAddressSupplier(uri));
 
                 if (logger.isDebugEnabled()) {
-                    SocketAddress socketAddress = SocketAddressResolver.resolve(redisURI, clientResources.dnsResolver());
+                    SocketAddress socketAddress = SocketAddressResolver.resolve(uri, clientResources.dnsResolver());
                     logger.debug("Connecting to Redis Sentinel, address: " + socketAddress);
                 }
                 try {


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
With debug logging enabled and a url which looks like ```redis-sentinel://secretpassword@hostorip1:27000,hostorip2:27000,hostorip3:27000#somemaster```, I get IllegalArgumentException("hostname can't be null"). With debug logging not enabled, no exception is thrown and the connection works.

I've not written a test, but I've run the code under a debugger, set a breakpoint just before the call, and verified that the old expression throws and the new expression resolves.

Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
