### PR TITLE
Include the transactional commands in RedisClusterAsyncCommands

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/api/async/RedisClusterAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/RedisClusterAsyncCommands.java
@@ -36,7 +36,7 @@ public interface RedisClusterAsyncCommands<K, V>
         extends RedisHashAsyncCommands<K, V>, RedisKeyAsyncCommands<K, V>, RedisStringAsyncCommands<K, V>,
         RedisListAsyncCommands<K, V>, RedisSetAsyncCommands<K, V>, RedisSortedSetAsyncCommands<K, V>,
         RedisScriptingAsyncCommands<K, V>, RedisServerAsyncCommands<K, V>, RedisHLLAsyncCommands<K, V>,
-        RedisGeoAsyncCommands<K, V>, BaseRedisAsyncCommands<K, V> {
+        RedisGeoAsyncCommands<K, V>, BaseRedisAsyncCommands<K, V>, RedisTransactionalAsyncCommands<K, V> {
 
     /**
      * Set the default timeout for operations.


### PR DESCRIPTION
Fixes #618 