### PR TITLE
weights param should be ignored if it is empty

### DIFF
--- a/src/main/java/com/lambdaworks/redis/ZStoreArgs.java
+++ b/src/main/java/com/lambdaworks/redis/ZStoreArgs.java
@@ -111,7 +111,7 @@ public class ZStoreArgs {
 
     <K, V> void build(CommandArgs<K, V> args) {
 
-        if (weights != null) {
+        if (weights != null && !weights.isEmpty()) {
 
             args.add(WEIGHTS);
             for (double weight : weights) {


### PR DESCRIPTION
when `private List<Double> weights;` is an empty list, the command will be generated like `ZUNIONSTORE out 2 zset1 zset2 WEIGHTS AGGREGATE MAX` which will be an redis error.


<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
