### PR TITLE
Treat slave-priority 0 as unavailable.

### DIFF
--- a/src/main/java/com/lambdaworks/redis/masterslave/SentinelTopologyProvider.java
+++ b/src/main/java/com/lambdaworks/redis/masterslave/SentinelTopologyProvider.java
@@ -108,6 +108,12 @@ public class SentinelTopologyProvider implements TopologyProvider {
                 return false;
             }
         }
+
+        String priority = map.get("slave-priority");
+        if (priority != null && priority.equals("0")) {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
As per Redis documentation, slaves given a priority of 0 are never promoted to master, so from the perspective of reading the Sentinel topology they should not be considered available nodes.

This prevents Lettuce making attempts to nodes which it does not have access to, which otherwise adds ~5 second delay to application startup.

Checked against 4.4.x HEAD, but applies to all Lettuce versions.

I don't see current tests for SentinelTopologyProvider so wasn't able to add/update one for the isAvailable function this PR changes, but happy to do that if the appropriate framework is added.