### PR TITLE
Fix ConnectionWatchDog won't reconnect problem in edge case

### DIFF
--- a/src/test/java/com/lambdaworks/redis/protocol/ConnectionFailureTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/ConnectionFailureTest.java
@@ -202,7 +202,7 @@ public class ConnectionFailureTest extends AbstractRedisClientTest {
 
             assertThat(connection.isOpen()).isFalse();
             connectionWatchdog.setReconnectSuspended(false);
-            connectionWatchdog.run(null);
+            connectionWatchdog.run();
             Thread.sleep(500);
             assertThat(connection.isOpen()).isFalse();
 

--- a/src/test/java/com/lambdaworks/redis/protocol/ConnectionFailureTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/ConnectionFailureTest.java
@@ -202,7 +202,7 @@ public class ConnectionFailureTest extends AbstractRedisClientTest {
 
             assertThat(connection.isOpen()).isFalse();
             connectionWatchdog.setReconnectSuspended(false);
-            connectionWatchdog.run();
+            connectionWatchdog.run(null);
             Thread.sleep(500);
             assertThat(connection.isOpen()).isFalse();
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

We met this problem again(https://github.com/lettuce-io/lettuce-core/issues/466), reconnectScheduleTimeout is not null but it's lastReconnectionLogging is far past(already few days).
And this time we really got `com.lambdaworks.redis.RedisException: Request queue size exceeded` for few days, occurred just after reconnectScheduleTimeout's time.

This change make assigning flag earlier, and I think this can solve the problem that reconnect `run()` runs earlier than assign back to `reconnectScheduleTimeout`.  And it's safe due to we didn't use returned `Timeout`.

- [x] It's hard to make test case, only possible to simulate using debug mode with per thread pausing. I will try more then remove `[WIP]`.
