### PR TITLE
Retain ssl/tls config from seed uris in Master/Slave context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,22 +285,6 @@ work/stunnel.conf:
 	@echo capath=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
 	@echo cafile=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
 
-	@echo [stunnel-master-slave-client-cert-node-1] >> $@
-	@echo accept = 127.0.0.1:8445 >> $@
-	@echo connect = 127.0.0.1:6482 >> $@
-	@echo cert=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
-	@echo key=$(ROOT_DIR)/work/ca/private/localhost.decrypted.key.pem >> $@
-	@echo cafile=$(ROOT_DIR)/work/ca/certs/ca.cert.pem >> $@
-	@echo verify=2 >> $@
-
-	@echo [stunnel-master-slave-client-cert-node-2] >> $@
-	@echo accept = 127.0.0.1:8446 >> $@
-	@echo connect = 127.0.0.1:6483 >> $@
-	@echo cert=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
-	@echo key=$(ROOT_DIR)/work/ca/private/localhost.decrypted.key.pem >> $@
-	@echo cafile=$(ROOT_DIR)/work/ca/certs/ca.cert.pem >> $@
-	@echo verify=2 >> $@
-
 work/stunnel.pid: work/stunnel.conf ssl-keys
 	which stunnel4 >/dev/null 2>&1 && stunnel4 $(ROOT_DIR)/work/stunnel.conf || stunnel $(ROOT_DIR)/work/stunnel.conf
 

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,37 @@ work/stunnel.conf:
 	@echo cafile=$(ROOT_DIR)/work/ca/certs/ca.cert.pem >> $@
 	@echo verify=2 >> $@
 
+	@echo [stunnel-master-slave-node-1] >> $@
+	@echo accept = 127.0.0.1:8443 >> $@
+	@echo connect = 127.0.0.1:6482 >> $@
+	@echo cert=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+	@echo key=$(ROOT_DIR)/work/ca/private/localhost.decrypted.key.pem >> $@
+	@echo capath=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+	@echo cafile=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+
+	@echo [stunnel-master-slave-node-2] >> $@
+	@echo accept = 127.0.0.1:8444 >> $@
+	@echo connect = 127.0.0.1:6483 >> $@
+	@echo cert=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+	@echo key=$(ROOT_DIR)/work/ca/private/localhost.decrypted.key.pem >> $@
+	@echo capath=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+	@echo cafile=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+
+	@echo [stunnel-master-slave-client-cert-node-1] >> $@
+	@echo accept = 127.0.0.1:8445 >> $@
+	@echo connect = 127.0.0.1:6482 >> $@
+	@echo cert=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+	@echo key=$(ROOT_DIR)/work/ca/private/localhost.decrypted.key.pem >> $@
+	@echo cafile=$(ROOT_DIR)/work/ca/certs/ca.cert.pem >> $@
+	@echo verify=2 >> $@
+
+	@echo [stunnel-master-slave-client-cert-node-2] >> $@
+	@echo accept = 127.0.0.1:8446 >> $@
+	@echo connect = 127.0.0.1:6483 >> $@
+	@echo cert=$(ROOT_DIR)/work/ca/certs/localhost.cert.pem >> $@
+	@echo key=$(ROOT_DIR)/work/ca/private/localhost.decrypted.key.pem >> $@
+	@echo cafile=$(ROOT_DIR)/work/ca/certs/ca.cert.pem >> $@
+	@echo verify=2 >> $@
 
 work/stunnel.pid: work/stunnel.conf ssl-keys
 	which stunnel4 >/dev/null 2>&1 && stunnel4 $(ROOT_DIR)/work/stunnel.conf || stunnel $(ROOT_DIR)/work/stunnel.conf

--- a/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionProvider.java
@@ -318,7 +318,11 @@ public class MasterSlaveConnectionProvider<K, V> {
         @Override
         public ConnectionFuture<StatefulRedisConnection<K, V>> apply(ConnectionKey key) {
 
-            RedisURI.Builder builder = RedisURI.Builder.redis(key.host, key.port);
+            RedisURI.Builder builder = RedisURI.Builder
+                    .redis(key.host, key.port)
+                    .withSsl(initialRedisUri.isSsl())
+                    .withVerifyPeer(initialRedisUri.isVerifyPeer())
+                    .withStartTls(initialRedisUri.isStartTls());
 
             if (initialRedisUri.getPassword() != null && initialRedisUri.getPassword().length != 0) {
                 builder.withPassword(initialRedisUri.getPassword());

--- a/src/main/java/io/lettuce/core/masterslave/RedisMasterSlaveNode.java
+++ b/src/main/java/io/lettuce/core/masterslave/RedisMasterSlaveNode.java
@@ -30,7 +30,11 @@ class RedisMasterSlaveNode implements RedisNodeDescription {
 
     public RedisMasterSlaveNode(String host, int port, RedisURI seed, Role role) {
 
-        RedisURI.Builder builder = RedisURI.Builder.redis(host, port);
+        RedisURI.Builder builder = RedisURI.Builder
+                .redis(host, port)
+                .withSsl(seed.isSsl())
+                .withVerifyPeer(seed.isVerifyPeer())
+                .withStartTls(seed.isStartTls());
         if (seed.getPassword() != null && seed.getPassword().length != 0) {
             builder.withPassword(new String(seed.getPassword()));
         }

--- a/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
+++ b/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
@@ -78,11 +78,11 @@ public class StaticMasterSlaveTopologyProvider implements TopologyProvider {
         Flux<RedisURI> uris = Flux.fromIterable(redisURIs);
         Mono<List<RedisNodeDescription>> nodes = uris.flatMap(uri -> getNodeDescription(connections, uri)) //
                 .collectList() //
-                .map((nodeDescriptions) -> {
+                .flatMap((nodeDescriptions) -> {
                     if (nodeDescriptions.isEmpty()) {
-                        throw new RedisConnectionException(String.format("Failed to connect to any nodes in %s", redisURIs));
+                        return Mono.error(new RedisConnectionException(String.format("Failed to connect to any nodes in %s", redisURIs)));
                     } else {
-                        return nodeDescriptions;
+                        return Mono.just(nodeDescriptions);
                     }
                 }) //
                 .doFinally(it -> {

--- a/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
+++ b/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
@@ -80,8 +80,7 @@ public class StaticMasterSlaveTopologyProvider implements TopologyProvider {
                 .collectList() //
                 .map((nodeDescriptions) -> {
                     if (nodeDescriptions.isEmpty()) {
-                        String msg = String.format("Failed to connect to any nodes in %s", redisURIs);
-                        throw new RedisConnectionException(msg);
+                        throw new RedisConnectionException(String.format("Failed to connect to any nodes in %s", redisURIs));
                     } else {
                         return nodeDescriptions;
                     }

--- a/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
+++ b/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
@@ -91,11 +91,7 @@ public class StaticMasterSlaveTopologyProvider implements TopologyProvider {
             RedisURI uri) {
 
         return Mono.fromCompletionStage(redisClient.connectAsync(StringCodec.UTF8, uri)) //
-                .onErrorResume(t -> {
-
-                    logger.warn("Cannot connect to {}", uri, t);
-                    return Mono.empty();
-                }) //
+                .doOnError(t -> logger.warn("Cannot connect to {}", uri, t)) //
                 .doOnNext(connections::add) //
                 .flatMap(connection -> {
 

--- a/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
+++ b/src/main/java/io/lettuce/core/masterslave/StaticMasterSlaveTopologyProvider.java
@@ -80,7 +80,7 @@ public class StaticMasterSlaveTopologyProvider implements TopologyProvider {
                 .collectList() //
                 .map((nodeDescriptions) -> {
                     if (nodeDescriptions.isEmpty()) {
-                        String msg = String.format("Failed to connect to any nodes in %s", uris);
+                        String msg = String.format("Failed to connect to any nodes in %s", redisURIs);
                         throw new RedisConnectionException(msg);
                     } else {
                         return nodeDescriptions;

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -15,20 +15,11 @@
  */
 package io.lettuce;
 
-import io.lettuce.core.*;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
-import io.lettuce.core.codec.StringCodec;
-import io.lettuce.core.masterslave.MasterSlave;
-import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
-import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
-import io.netty.handler.codec.DecoderException;
-import io.netty.handler.ssl.OpenSsl;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.springframework.test.util.ReflectionTestUtils;
+import static io.lettuce.core.TestSettings.host;
+import static io.lettuce.core.TestSettings.sslPort;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -40,11 +31,22 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static io.lettuce.core.TestSettings.host;
-import static io.lettuce.core.TestSettings.sslPort;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assume.assumeTrue;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.lettuce.core.*;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.masterslave.MasterSlave;
+import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
+import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.ssl.OpenSsl;
+
 
 /**
  * @author Mark Paluch

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -58,13 +58,14 @@ public class SslTest extends AbstractTest {
     private static final File TRUSTSTORE_FILE = new File(TRUSTSTORE);
     private static final int MASTER_SLAVE_BASE_PORT_OFFSET = 2000;
 
+    private static final RedisURI URI_NO_VERIFY = sslURIBuilder(0) //
+            .withVerifyPeer(false) //
+            .build();
+
     private static final RedisURI URI_VERIFY = sslURIBuilder(1) //
             .withVerifyPeer(true) //
             .build();
 
-    private static final RedisURI URI_NO_VERIFY = sslURIBuilder(0)
-            .withVerifyPeer(false) //
-            .build();
 
     private static final RedisURI URI_CLIENT_CERT_AUTH = sslURIBuilder(2) //
             .withVerifyPeer(true) //

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -88,15 +88,6 @@ public class SslTest extends AbstractTest {
                     .withVerifyPeer(true)
                     .build());
 
-
-    private static final List<RedisURI> MASTER_SLAVE_URIS_CLIENT_CERT_AUTH = Arrays.asList(
-            masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 2)
-                    .withVerifyPeer(true)
-                    .build(),
-            masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 3)
-                    .withVerifyPeer(true)
-                    .build());
-
     private static RedisClient redisClient;
 
     @BeforeClass
@@ -283,32 +274,6 @@ public class SslTest extends AbstractTest {
         setOptions(sslOptions);
 
         verifyMasterSlaveConnection(MASTER_SLAVE_URIS_VERIFY);
-    }
-
-    @Test
-    public void masterSlaveWithClientCertificates() throws Exception {
-
-        SslOptions sslOptions = SslOptions.builder() //
-                .jdkSslProvider() //
-                .keystore(new File(KEYSTORE), "changeit".toCharArray()) //
-                .truststore(TRUSTSTORE_FILE) //
-                .build();
-        setOptions(sslOptions);
-
-        verifyMasterSlaveConnection(MASTER_SLAVE_URIS_CLIENT_CERT_AUTH);
-    }
-
-
-    @Test(expected = RedisConnectionException.class)
-    public void masterSlaveWithClientCertificatesWithoutKeystore() throws Exception {
-
-        SslOptions sslOptions = SslOptions.builder() //
-                .jdkSslProvider() //
-                .truststore(TRUSTSTORE_FILE) //
-                .build();
-        setOptions(sslOptions);
-
-        verifyMasterSlaveConnection(MASTER_SLAVE_URIS_CLIENT_CERT_AUTH);
     }
 
     @Test(expected = RedisConnectionException.class)

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -72,19 +72,19 @@ public class SslTest extends AbstractTest {
             .build();
 
     private static final List<RedisURI> MASTER_SLAVE_URIS_NO_VERIFY = Arrays.asList(
-            masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET)
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET)
                     .withVerifyPeer(false)
                     .build(),
-            masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 1)
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 1)
                     .withVerifyPeer(false)
                     .build());
 
 
     private static final List<RedisURI> MASTER_SLAVE_URIS_VERIFY = Arrays.asList(
-            masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET)
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET)
                     .withVerifyPeer(true)
                     .build(),
-            masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 1)
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 1)
                     .withVerifyPeer(true)
                     .build());
 
@@ -392,12 +392,6 @@ public class SslTest extends AbstractTest {
     private static RedisURI.Builder sslURIBuilder(int portOffset) {
         return RedisURI.Builder.redis(host(), sslPort(portOffset))
                 .withSsl(true);
-    }
-
-    private static RedisURI.Builder masterSlaveSSLURIBuilder(int portOffset) {
-        return sslURIBuilder(portOffset)
-                // TODO - why do the master/slave tests need this but the standalone ones don't???
-                .withTimeout(Duration.of(500, ChronoUnit.MILLIS));
     }
 
     private URL truststoreURL() throws MalformedURLException {

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -58,8 +58,16 @@ public class SslTest extends AbstractTest {
     private static final File TRUSTSTORE_FILE = new File(TRUSTSTORE);
     private static final int MASTER_SLAVE_BASE_PORT_OFFSET = 2000;
 
+    private static final RedisURI URI_VERIFY = sslURIBuilder(1) //
+            .withVerifyPeer(true) //
+            .build();
+
     private static final RedisURI URI_NO_VERIFY = sslURIBuilder(0)
             .withVerifyPeer(false) //
+            .build();
+
+    private static final RedisURI URI_CLIENT_CERT_AUTH = sslURIBuilder(2) //
+            .withVerifyPeer(true) //
             .build();
 
     private static final List<RedisURI> MASTER_SLAVE_URIS_NO_VERIFY = Arrays.asList(
@@ -70,9 +78,6 @@ public class SslTest extends AbstractTest {
                     .withVerifyPeer(false)
                     .build());
 
-    private static final RedisURI URI_VERIFY = sslURIBuilder(1) //
-            .withVerifyPeer(true) //
-            .build();
 
     private static final List<RedisURI> MASTER_SLAVE_URIS_VERIFY = Arrays.asList(
             masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET)
@@ -82,9 +87,6 @@ public class SslTest extends AbstractTest {
                     .withVerifyPeer(true)
                     .build());
 
-    private static final RedisURI URI_CLIENT_CERT_AUTH = sslURIBuilder(2) //
-            .withVerifyPeer(true) //
-            .build();
 
     private static final List<RedisURI> MASTER_SLAVE_URIS_CLIENT_CERT_AUTH = Arrays.asList(
             masterSlaveSSLURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 2)

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -88,6 +88,25 @@ public class SslTest extends AbstractTest {
                     .withVerifyPeer(true)
                     .build());
 
+    private static final List<RedisURI> MASTER_SLAVE_URIS_WITH_ONE_INVALID = Arrays.asList(
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET)
+                    .withVerifyPeer(true)
+                    .build(),
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 1)
+                    .withVerifyPeer(true)
+                    .build(),
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 2)
+                    .withVerifyPeer(true)
+                    .build());
+
+    private static final List<RedisURI> MASTER_SLAVE_URIS_WITH_ALL_INVALID = Arrays.asList(
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 2)
+                    .withVerifyPeer(true)
+                    .build(),
+            sslURIBuilder(MASTER_SLAVE_BASE_PORT_OFFSET + 3)
+                    .withVerifyPeer(true)
+                    .build());
+
     private static RedisClient redisClient;
 
     @BeforeClass
@@ -320,6 +339,30 @@ public class SslTest extends AbstractTest {
     @Test(expected = RedisConnectionException.class)
     public void masterSlaveSslWithVerificationWillFail() {
         MasterSlave.connect(redisClient, StringCodec.UTF8, MASTER_SLAVE_URIS_VERIFY);
+    }
+
+    @Test
+    public void masterSlaveSslWithOneInvalidHostWillSucceed() {
+
+        SslOptions sslOptions = SslOptions.builder() //
+                .jdkSslProvider() //
+                .truststore(TRUSTSTORE_FILE) //
+                .build();
+        setOptions(sslOptions);
+
+        verifyMasterSlaveConnection(MASTER_SLAVE_URIS_WITH_ONE_INVALID);
+    }
+
+    @Test(expected = RedisConnectionException.class)
+    public void masterSlaveSslWithAllInvalidHostsWillFail() {
+
+        SslOptions sslOptions = SslOptions.builder() //
+                .jdkSslProvider() //
+                .truststore(TRUSTSTORE_FILE) //
+                .build();
+        setOptions(sslOptions);
+
+        verifyMasterSlaveConnection(MASTER_SLAVE_URIS_WITH_ALL_INVALID);
     }
 
     @Test

--- a/src/test/java/io/lettuce/SslTest.java
+++ b/src/test/java/io/lettuce/SslTest.java
@@ -300,33 +300,6 @@ public class SslTest extends AbstractTest {
     }
 
     @Test
-    public void masterSlaveWithOpenSsl() {
-
-        assumeTrue(OpenSsl.isAvailable());
-
-        SslOptions sslOptions = SslOptions.builder() //
-                .openSslProvider() //
-                .truststore(TRUSTSTORE_FILE) //
-                .build();
-        setOptions(sslOptions);
-
-        verifyMasterSlaveConnection(MASTER_SLAVE_URIS_VERIFY);
-    }
-
-    @Test(expected = RedisConnectionException.class)
-    public void masterSlaveWithOpenSslFailsWithWrongTruststore() {
-
-        assumeTrue(OpenSsl.isAvailable());
-
-        SslOptions sslOptions = SslOptions.builder() //
-                .openSslProvider() //
-                .build();
-        setOptions(sslOptions);
-
-        verifyMasterSlaveConnection(MASTER_SLAVE_URIS_VERIFY);
-    }
-
-    @Test
     public void masterSlavePingBeforeActivate() {
 
         redisClient.setOptions(ClientOptions.builder().pingBeforeActivateConnection(true).build());

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslTest.java
@@ -47,7 +47,7 @@ public class RedisClusterPasswordSecuredSslTest extends AbstractTest {
     public static final String SLOT_1_KEY = "8HMdi";
     public static final String SLOT_16352_KEY = "UyAa4KqoWgPGKa";
 
-    public static RedisURI redisURI = RedisURI.Builder.redis(host(), CLUSTER_PORT_SSL_1).withPassword("foobared")
+    public static RedisURI redisURI = RedisURI.builder().redis(host(), CLUSTER_PORT_SSL_1).withPassword("foobared")
             .withSsl(true).withVerifyPeer(false).build();
     public static RedisClusterClient redisClient = RedisClusterClient.create(TestClientResources.get(), redisURI);
 

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslTest.java
@@ -47,7 +47,7 @@ public class RedisClusterPasswordSecuredSslTest extends AbstractTest {
     public static final String SLOT_1_KEY = "8HMdi";
     public static final String SLOT_16352_KEY = "UyAa4KqoWgPGKa";
 
-    public static RedisURI redisURI = RedisURI.builder().redis(host(), CLUSTER_PORT_SSL_1).withPassword("foobared")
+    public static RedisURI redisURI = RedisURI.Builder.redis(host(), CLUSTER_PORT_SSL_1).withPassword("foobared")
             .withSsl(true).withVerifyPeer(false).build();
     public static RedisClusterClient redisClient = RedisClusterClient.create(TestClientResources.get(), redisURI);
 
@@ -132,7 +132,7 @@ public class RedisClusterPasswordSecuredSslTest extends AbstractTest {
     @Test
     public void connectionWithoutPasswordShouldFail() throws Exception {
 
-        RedisURI redisURI = RedisURI.builder().redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
+        RedisURI redisURI = RedisURI.Builder.redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
         RedisClusterClient redisClusterClient = RedisClusterClient.create(TestClientResources.get(), redisURI);
 
         try {
@@ -147,7 +147,7 @@ public class RedisClusterPasswordSecuredSslTest extends AbstractTest {
     @Test
     public void connectionWithoutPasswordShouldFail2() throws Exception {
 
-        RedisURI redisURI = RedisURI.builder().redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
+        RedisURI redisURI = RedisURI.Builder.redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
         RedisClusterClient redisClusterClient = RedisClusterClient.create(TestClientResources.get(), redisURI);
 
         try {

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslTest.java
@@ -132,7 +132,7 @@ public class RedisClusterPasswordSecuredSslTest extends AbstractTest {
     @Test
     public void connectionWithoutPasswordShouldFail() throws Exception {
 
-        RedisURI redisURI = RedisURI.Builder.redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
+        RedisURI redisURI = RedisURI.builder().redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
         RedisClusterClient redisClusterClient = RedisClusterClient.create(TestClientResources.get(), redisURI);
 
         try {
@@ -147,7 +147,7 @@ public class RedisClusterPasswordSecuredSslTest extends AbstractTest {
     @Test
     public void connectionWithoutPasswordShouldFail2() throws Exception {
 
-        RedisURI redisURI = RedisURI.Builder.redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
+        RedisURI redisURI = RedisURI.builder().redis(host(), CLUSTER_PORT_SSL_1).withSsl(true).withVerifyPeer(false).build();
         RedisClusterClient redisClusterClient = RedisClusterClient.create(TestClientResources.get(), redisURI);
 
         try {


### PR DESCRIPTION
Still WIP, but I'm opening this to start a discussion.

The problem I'm trying to solve is the combination of an AWS Elasticache redis cluster (in master-slave cluster-mode) w/ their recently added in-transit encryption. We aren't currently using redis cluster because of the need for at least 3 primary nodes + any optional layer of replicas, and we're rather satisfied w/ the simplicity of master/slave replication and the minimal node count per cluster that it gives.

I'm experimenting to see if I can somehow get a static Master/Slave topology + SSL to work. Before this PR, it simply isn't possible to create a static master/slave topology w/ something like: `MasterSlave.connect(client, codec, Arrays.asList("rediss://foo0.bar.baz", "rediss://foo1.bar.baz"))`. The initial connections all fail because the ssl/tls-related uri info is dropped in the conversion of the `RedisMasterSlaveNode` objects. 

Once I added that, the initial SSL handshake succeeded, but the connection didn't actually succeed, and I saw an endless stream of logs like this:
```
...
INFO  [2018-01-24T05:00:08.495Z] [] [] [lettuce-nioEventLoop-4-2]: io.lettuce.core.protocol.ReconnectionHandler: Reconnected to abc.xyz.nzcsol.use1.cache.amazonaws.com:6379
INFO  [2018-01-24T05:00:08.496Z] [] [] [lettuce-nioEventLoop-4-1]: io.lettuce.core.protocol.ReconnectionHandler: Reconnected to abc.xyz.nzcsol.use1.cache.amazonaws.com:6379
INFO  [2018-01-24T05:00:08.592Z] [] [] [lettuce-nioEventLoop-4-3]: io.lettuce.core.protocol.ReconnectionHandler: Reconnected to abc.xyz.nzcsol.use1.cache.amazonaws.com:6379
INFO  [2018-01-24T05:00:08.594Z] [] [] [lettuce-nioEventLoop-4-4]: io.lettuce.core.protocol.ReconnectionHandler: Reconnected to abc.xyz.nzcsol.use1.cache.amazonaws.com:6379
...
```

Digging in further, I found that the `MasterSlaveConnectionProvider` was ignoring any ssl/tls info present in the seed uri, and fixing _that_ finally let me create and connect to the static master/slave topology over ssl. Now, I see these log lines as the stateful connection objects are getting wired up at app startup time 
```
WARN  [2018-01-24T19:27:27.822Z] [] [] [lettuce-nioEventLoop-4-2]: io.lettuce.core.RedisChannelHandler: Connection is already closed
WARN  [2018-01-24T19:27:27.822Z] [] [] [lettuce-nioEventLoop-4-1]: io.lettuce.core.RedisChannelHandler: Connection is already closed
```

I create a few different stateful connections to the same cluster because each of the call sites have slightly different uses. 

## Open Questions
* ~~Does this feel like it's headed in the right direction?~~
* Any thoughts on the `Connection is already closed` warnings?
* ~~What branch should I work from for the final PR? We were currently on a 4.x release, but I went ahead and upgraded our dep to the `5.0.1-RELEASE` when I started investigating the failures to connect.~~
* ~~Test coverage - I obviously don't have any yet, but I want to get some input on the direction, first.~~
* Blind spots - what am I missing from this being my first time to dig into the actual library code? Do you see any immediate issues w/ this for dynamic master/slave topologies, sentinel topologies, etc?