### PR TITLE
Fix for UnsupportedOperationException during KeyValueListOutput.set

### DIFF
--- a/src/main/java/io/lettuce/core/output/KeyValueListOutput.java
+++ b/src/main/java/io/lettuce/core/output/KeyValueListOutput.java
@@ -16,6 +16,7 @@
 package io.lettuce.core.output;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -48,6 +49,10 @@ public class KeyValueListOutput<K, V> extends CommandOutput<K, V, List<KeyValue<
 
     @Override
     public void set(ByteBuffer bytes) {
+
+        if (!initialized) {
+            output = new ArrayList<>();
+        }
 
         if (keyIterator == null) {
             keyIterator = keys.iterator();


### PR DESCRIPTION
Similar solution for problem reported in https://github.com/lettuce-io/lettuce-core/issues/589 but unfortunatelly can't reproduce this problem in test