### PR TITLE
Fix #712 by introducing isLoadBalancer field in RedisURI

### DIFF
--- a/src/main/java/com/lambdaworks/redis/RedisURI.java
+++ b/src/main/java/com/lambdaworks/redis/RedisURI.java
@@ -173,6 +173,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
     private long timeout = 60;
     private TimeUnit unit = TimeUnit.SECONDS;
     private final List<RedisURI> sentinels = new ArrayList<>();
+    private boolean isLoadBalancer = false;
 
     /**
      * Default empty constructor.
@@ -483,6 +484,24 @@ public class RedisURI implements Serializable, ConnectionPoint {
      */
     public List<RedisURI> getSentinels() {
         return sentinels;
+    }
+
+    /**
+     * Load balancer is not considered as cluster node, only for node discovery
+     *
+     * @return {@literal true} if it's a load balancer.
+     */
+    public boolean isLoadBalancer() {
+        return isLoadBalancer;
+    }
+
+    /**
+     * Sets whether it's a load balancer URI
+     *
+     * @param isLoadBalancer {@literal true} if it's a load balancer.
+     */
+    public void setLoadBalancer(boolean isLoadBalancer){
+        this.isLoadBalancer = isLoadBalancer;
     }
 
     /**
@@ -946,6 +965,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
         private long timeout = 60;
         private TimeUnit unit = TimeUnit.SECONDS;
         private final List<HostAndPort> sentinels = new ArrayList<>();
+        private boolean isLoadBalancer = false;
 
         /**
          * @deprecated Use {@link RedisURI#builder()}
@@ -1226,6 +1246,17 @@ public class RedisURI implements Serializable, ConnectionPoint {
         }
 
         /**
+         * If a {@link RedisURI} is load balancer, node with {@link com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode.NodeFlag#MYSELF} will not be replaced by this {@link RedisURI} in cluster node discovery
+         *
+         * @param isLoadBalancer {@literal true} if is load balancer
+         * @return the builder
+         */
+        public Builder withLoadBalancer(boolean isLoadBalancer) {
+            this.isLoadBalancer = isLoadBalancer;
+            return this;
+        }
+
+        /**
          * Configures a sentinel master Id.
          *
          * @param sentinelMasterId sentinel master id, must not be empty or {@literal null}
@@ -1271,6 +1302,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
 
             redisURI.setTimeout(timeout);
             redisURI.setUnit(unit);
+            redisURI.setLoadBalancer(isLoadBalancer);
 
             return redisURI;
         }

--- a/src/main/java/com/lambdaworks/redis/cluster/topology/NodeTopologyView.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/topology/NodeTopologyView.java
@@ -61,8 +61,6 @@ class NodeTopologyView {
         this.clusterNodes = clusterNodes;
         this.clientList = clientList;
         this.latency = latency;
-
-        getOwnPartition().setUri(redisURI);
     }
 
     static NodeTopologyView from(RedisURI redisURI, Requests clusterNodesRequests, Requests clientListRequests)

--- a/src/main/java/com/lambdaworks/redis/cluster/topology/NodeTopologyView.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/topology/NodeTopologyView.java
@@ -61,6 +61,10 @@ class NodeTopologyView {
         this.clusterNodes = clusterNodes;
         this.clientList = clientList;
         this.latency = latency;
+
+        if(!redisURI.isLoadBalancer()){
+            getOwnPartition().setUri(redisURI);
+        }
     }
 
     static NodeTopologyView from(RedisURI redisURI, Requests clusterNodesRequests, Requests clientListRequests)


### PR DESCRIPTION
Setting isLoadBalancer as true if seed node is load balancer to avoid real redis node is replaced by load balancer URI.