### PR TITLE
Ensure firstResponseLatency metric is a positive number (issue #740)

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
@@ -466,7 +466,7 @@ public class CommandHandler<K, V> extends ChannelDuplexHandler implements RedisC
 
         if (withLatency != null && latencyMetricsEnabled && channel != null && remote() != null) {
 
-            long firstResponseLatency = withLatency.getSent() - withLatency.getFirstResponse();
+            long firstResponseLatency = withLatency.getFirstResponse() - withLatency.getSent();
             long completionLatency = nanoTime() - withLatency.getSent();
 
             clientResources.commandLatencyCollector().recordCommandLatency(local(), remote(), commandType,


### PR DESCRIPTION
Is it all right if I skip testing it? 

Rationale:
* The unit tests don't appear to directly address `decode()` or `recordLatency()`
* my Mockito skills are very weak
* this is such a quick change :)
