### PR TITLE
Returning a list of values from hmget in 5.X 

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -710,6 +710,11 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisHashAsync
     }
 
     @Override
+    public RedisFuture<List<V>> hmgetlist(K key, K... fields) {
+        return dispatch(commandBuilder.hmget(key, fields));
+    }
+
+    @Override
     public RedisFuture<Long> hmget(KeyValueStreamingChannel<K, V> channel, K key, K... fields) {
         return dispatch(commandBuilder.hmget(channel, key, fields));
     }

--- a/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
@@ -136,7 +136,7 @@ public interface RedisHashAsyncCommands<K, V> {
      *
      * @param key the key
      * @param fields the field type: key
-     * @return List<KeyValue<K, V>> array-reply list of KeyValue containing the keys and values associated with the given fields, in the same
+     * @return List&lt;KeyValue&lt;K, V&gt;&gt; array-reply list of KeyValue containing the keys and values associated with the given fields, in the same
      */
     RedisFuture<List<KeyValue<K, V>>> hmget(K key, K... fields);
 
@@ -145,7 +145,7 @@ public interface RedisHashAsyncCommands<K, V> {
      *
      * @param key the key
      * @param fields the field type: key
-     * @return List<V> array-reply list of values associated with the given fields, in the same
+     * @return List&lt;V&gt; array-reply list of values associated with the given fields, in the same
      */
     RedisFuture<List<V>> hmgetlist(K key, K... fields);
 

--- a/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
@@ -136,9 +136,18 @@ public interface RedisHashAsyncCommands<K, V> {
      *
      * @param key the key
      * @param fields the field type: key
-     * @return List&lt;V&gt; array-reply list of values associated with the given fields, in the same
+     * @return List<KeyValue<K, V>> array-reply list of KeyValue containing the keys and values associated with the given fields, in the same
      */
     RedisFuture<List<KeyValue<K, V>>> hmget(K key, K... fields);
+
+    /**
+     * Get the values of all the given hash fields.
+     *
+     * @param key the key
+     * @param fields the field type: key
+     * @return List<V> array-reply list of values associated with the given fields, in the same
+     */
+    RedisFuture<List<V>> hmgetlist(K key, K... fields);
 
     /**
      * Stream over the values of all the given hash fields.

--- a/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
@@ -138,6 +138,15 @@ public interface RedisHashCommands<K, V> {
      * @param fields the field type: key
      * @return List&lt;V&gt; array-reply list of values associated with the given fields, in the same
      */
+    List<V> hmgetlist(K key, K... fields);
+
+    /**
+     * Get the values of all the given hash fields.
+     *
+     * @param key the key
+     * @param fields the field type: key
+     * @return List&lt;KeyValue&lt;K, V&gt;&gt; array-reply list of KeyValue containing the keys and values associated with the given fields, in the same
+     */
     List<KeyValue<K, V>> hmget(K key, K... fields);
 
     /**

--- a/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
@@ -137,6 +137,15 @@ public interface RedisHashCommands<K, V> {
      * @param fields the field type: key
      * @return List&lt;V&gt; array-reply list of values associated with the given fields, in the same
      */
+    List<V> hmgetlist(K key, K... fields);
+
+    /**
+     * Get the values of all the given hash fields.
+     *
+     * @param key the key
+     * @param fields the field type: key
+     * @return List&lt;KeyValue&lt;K, V&gt;&gt; array-reply list of KeyValue containing the keys and values associated with the given fields, in the same
+     */
     List<KeyValue<K, V>> hmget(K key, K... fields);
 
     /**

--- a/src/test/java/io/lettuce/core/commands/HashCommandTest.java
+++ b/src/test/java/io/lettuce/core/commands/HashCommandTest.java
@@ -157,6 +157,14 @@ public class HashCommandTest extends AbstractRedisClientTest {
         assertThat(values.containsAll(list(kv("one", "1"), kv("two", "2")))).isTrue();
     }
 
+    @Test
+    public void hmgetlist() {
+        setupHmget();
+        List<String> values = redis.hmgetlist(key, "one", "two");
+        assertThat(values).hasSize(2);
+        assertThat(values.containsAll(list(kv("one", "1"), kv("two", "2")))).isTrue();
+    }
+
     private void setupHmget() {
         assertThat(redis.hmget(key, "one", "two")).isEqualTo(list(KeyValue.empty("one"), KeyValue.empty("two")));
         redis.hset(key, "one", "1");


### PR DESCRIPTION
Hi!

I'd like to use `hmget` in 5.X to get a simple list of values. This is the default for older versions, but in 5.X it's currently returning a `List<KeyValue<K, V>>`. 

Added `hmgetlist` to return a `List<V>`. 
