### PR TITLE
Remove Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 lettuce - Advanced Java Redis client
 ===============================
 
-[![Build Status](https://travis-ci.org/lettuce-io/lettuce-core.svg)](https://travis-ci.org/lettuce-io/lettuce-core) [![codecov](https://codecov.io/gh/lettuce-io/lettuce-core/branch/master/graph/badge.svg)](https://codecov.io/gh/lettuce-io/lettuce-core)
- [![Maven Central](https://maven-badges.herokuapp.com/maven-central/biz.paluch.redis/lettuce/badge.svg)](https://maven-badges.herokuapp.com/maven-central/biz.paluch.redis/lettuce)
+[![Build Status](https://travis-ci.org/lettuce-io/lettuce-core.svg)](https://travis-ci.org/lettuce-io/lettuce-core)
+[![codecov](https://codecov.io/gh/lettuce-io/lettuce-core/branch/master/graph/badge.svg)](https://codecov.io/gh/lettuce-io/lettuce-core)
 
 Lettuce is a scalable thread-safe Redis client for synchronous,
 asynchronous and reactive usage. Multiple threads may share one connection if they avoid blocking and transactional


### PR DESCRIPTION
~Updates the Maven Central badge in the README to the new artifact coordinates.~

Removes the Maven Central badge in the README since the 4.x artifact is superseded by the 5.x artifact, which is maintained in a different branch.