### PR TITLE
Fix recordCommandLatency to work properly

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/CommandHandler.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandHandler.java
@@ -465,7 +465,7 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
             if (promise.isVoid()) {
                 stack.add(redisCommand);
             } else {
-                promise.addListener(AddToStack.newInstance(stack, command));
+                promise.addListener(AddToStack.newInstance(stack, redisCommand));
             }
         } catch (Exception e) {
             command.completeExceptionally(e);

--- a/src/test/java/io/lettuce/core/protocol/CommandHandlerUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/CommandHandlerUnitTests.java
@@ -406,9 +406,7 @@ class CommandHandlerUnitTests {
         sut.channelRegistered(context);
         sut.channelActive(context);
 
-        LatencyMeteredCommand<String, String, String> wrapped = new LatencyMeteredCommand<>(command);
-
-        sut.write(context, wrapped, channelPromise);
+        sut.write(context, command, channelPromise);
         Delay.delay(Duration.ofMillis(10));
 
         sut.channelRead(context, Unpooled.wrappedBuffer("*1\r\n+OK\r\n".getBytes()));


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

In previous commit f350431e54e8a7a2e49da7658686a61e18f2906b , wrapped `redisCommand` was changed to `command`. And, `recordCommandLatency()` is not called properly in `5.1.0.RELEASE`, because `DefaultChannelPromise.isVoid() == false`. This PR fixed it.

Here is a sample for user-side: https://gist.github.com/jongyeol/edd80cb080aaab1fa619c7001b0ccbed