### PR TITLE
Bug: Include hostPortString in the error message

### DIFF
--- a/src/main/java/io/lettuce/core/internal/HostAndPort.java
+++ b/src/main/java/io/lettuce/core/internal/HostAndPort.java
@@ -192,7 +192,7 @@ public class HostAndPort {
         int closeBracketIndex = hostPortString.lastIndexOf(']');
 
         LettuceAssert.isTrue(colonIndex > -1 && closeBracketIndex > colonIndex,
-                String.format("Invalid bracketed host/port: ", hostPortString));
+                String.format("Invalid bracketed host/port: %s", hostPortString));
 
         String host = hostPortString.substring(1, closeBracketIndex);
         if (closeBracketIndex + 1 == hostPortString.length()) {


### PR DESCRIPTION
The host and port wasn't included in the error message for `Invalid bracketed host/port` due to a missing `%s`.