### PR TITLE
Makefile refactor download redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,8 +387,6 @@ work/redis-git/src/redis-cli work/redis-git/src/redis-server:
 	$(MAKE) -C work/redis-git clean
 	$(MAKE) -C work/redis-git -j4
 
-.PHONY: work/redis-git/src/redis-cli work/redis-git/src/redis-server
-
 clean:
 	rm -Rf work/
 	rm -Rf target/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 PATH := ./work/redis-git/src:${PATH}
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 STUNNEL_BIN := $(shell which stunnel)
@@ -380,10 +381,13 @@ endif
 endif
 
 work/redis-git/src/redis-cli work/redis-git/src/redis-server:
-	[ -d work/redis-git ] && ( cd work/redis-git && git reset --hard && git checkout $(REDIS) && git pull ) || \
-	git clone https://github.com/antirez/redis.git --depth 1 -b unstable work/redis-git
+	[ -d "work/redis-git" ] && cd work/redis-git && git reset --hard || \
+	git clone https://github.com/antirez/redis.git work/redis-git
+	cd work/redis-git && git checkout -q $(REDIS) && git pull origin $(REDIS)
 	$(MAKE) -C work/redis-git clean
 	$(MAKE) -C work/redis-git -j4
+
+.PHONY: work/redis-git/src/redis-cli work/redis-git/src/redis-server
 
 clean:
 	rm -Rf work/

--- a/Makefile
+++ b/Makefile
@@ -380,11 +380,8 @@ endif
 endif
 
 work/redis-git/src/redis-cli work/redis-git/src/redis-server:
-	[ ! -e work/redis-git ] && git clone https://github.com/antirez/redis.git work/redis-git && cd work/redis-git && git checkout $(REDIS) || true
-	$(eval REDIS_BRANCH = -v $(shell git -C work/redis-git branch --no-color | sed 's/\* //g'))
-	cd work/redis-git && git reset --hard || true
-	[ "$(REDIS)" != "$(REDIS_BRANCH)" ] && cd work/redis-git && git checkout $(REDIS) || true
-	[ "$(REDIS)" == "unstable" ] && cd work/redis-git && git fetch && git merge origin/unstable || true
+	[ -d work/redis-git ] && ( cd work/redis-git && git reset --hard && git checkout $(REDIS) && git pull ) || \
+	git clone https://github.com/antirez/redis.git --depth 1 -b unstable work/redis-git
 	$(MAKE) -C work/redis-git clean
 	$(MAKE) -C work/redis-git -j4
 


### PR DESCRIPTION
## Description
- Simplified the logic for the make target `work/redis-git/src/redis-server`
- Set a shell version to bash. Ubuntu was defaulting to `/bin/sh` which caused the `[ "$(REDIS)" == "unstable" ]` expression to error out


Pseudo code for changes to the make target `work/redis-git/src/redis-server`
Originally it was doing this.

```js
if( !hasRedisGitDir ){
    downloadRedisGit()
    checkoutAndPullBranch( REDIS )
}
REDIS_BRANCH = getBranchName()
gitResetBranch()
if( REDIS != REDIS_BRANCH ){
    checkoutAndPullBranch( REDIS )
}
if( REDIS == DEFAULT_REDIS_BRANCH ){
    checkoutAndPullBranch( REDIS )
}
```

Rewrote it to do this
```js
if( hasRedisGitDir ){
    gitResetBranch()
} else {
    downloadRedisGit()
}
checkoutAndPullBranch( REDIS )
```

### Test command

```bash
clear
make clean && make 'work/redis-git/src/redis-server'
make clean && make 'work/redis-git/src/redis-server' REDIS=3.2.11
make clean && make 'work/redis-git/src/redis-server' REDIS=4.0.11
```

### Test command output

```bash
[ -d "work/redis-git" ] && cd work/redis-git && git reset --hard || \
git clone https://github.com/antirez/redis.git work/redis-git
Cloning into 'work/redis-git'...
remote: Enumerating objects: 12, done.
remote: Counting objects: 100% (12/12), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 54635 (delta 4), reused 7 (delta 4), pack-reused 54623
Receiving objects: 100% (54635/54635), 73.10 MiB | 2.76 MiB/s, done.
Resolving deltas: 100% (38472/38472), done.
cd work/redis-git && git checkout -q unstable && git pull origin unstable
From https://github.com/antirez/redis
 * branch              unstable   -> FETCH_HEAD
Already up to date.

*** NOTE: make steps remove from output

[ -d "work/redis-git" ] && cd work/redis-git && git reset --hard || \
git clone https://github.com/antirez/redis.git work/redis-git
HEAD is now at 3d07ed98 Fix typo in replicationCron() comment.
cd work/redis-git && git checkout -q 3.2.11 && git pull origin 3.2.11
From https://github.com/antirez/redis
 * tag                 3.2.11     -> FETCH_HEAD
Already up to date.

*** NOTE: make steps remove from output

[ -d "work/redis-git" ] && cd work/redis-git && git reset --hard || \
git clone https://github.com/antirez/redis.git work/redis-git
HEAD is now at 1cb6effd Redis 3.2.11.
cd work/redis-git && git checkout -q 4.0.11 && git pull origin 4.0.11
From https://github.com/antirez/redis
 * tag                 4.0.11     -> FETCH_HEAD
Already up to date.

*** NOTE: make steps remove from output
```
