### PR TITLE
Fixed stackoverflow exception inside CommandLatencyCollectorOptions

### DIFF
--- a/src/main/java/io/lettuce/core/metrics/CommandLatencyCollectorOptions.java
+++ b/src/main/java/io/lettuce/core/metrics/CommandLatencyCollectorOptions.java
@@ -51,7 +51,7 @@ public interface CommandLatencyCollectorOptions {
      * @since 5.1
      */
     static CommandLatencyCollectorOptions.Builder builder() {
-        return CommandLatencyCollectorOptions.builder();
+        return DefaultCommandLatencyCollectorOptions.builder();
     }
 
     /**

--- a/src/test/java/io/lettuce/core/metrics/CommandLatencyCollectorOptionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/metrics/CommandLatencyCollectorOptionsUnitTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lettuce.core.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommandLatencyCollectorOptionsUnitTests {
+
+    @Test()
+    void testBuilder() {
+
+        CommandLatencyCollectorOptions sut = CommandLatencyCollectorOptions.builder()
+                .targetUnit(TimeUnit.HOURS).targetPercentiles(new double[] { 1, 2, 3 }).build();
+
+        assertThat(sut.targetPercentiles()).hasSize(3);
+        assertThat(sut.targetUnit()).isEqualTo(TimeUnit.HOURS);
+    }
+}


### PR DESCRIPTION
## Problem:

`CommandLatencyCollectorOptions.builder()` calls itself to form a stackoverflow exception.

## Solution:

`CommandLatencyCollectorOptions.builder()` now calls `DefaultCommandLatencyCollectorOptions.builder()`