### PR TITLE
Add hasSameSlotsOf method to RedisClusterNode for a quick slots comparison

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -255,6 +255,11 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         }
     }
 
+    public boolean hasSameSlotsOf(RedisClusterNode other) {
+        if (other == null) return false;
+        else return this.slots.equals(other.slots);
+    }
+
     public Set<NodeFlag> getFlags() {
         return flags;
     }

--- a/src/main/java/io/lettuce/core/cluster/topology/TopologyComparators.java
+++ b/src/main/java/io/lettuce/core/cluster/topology/TopologyComparators.java
@@ -154,7 +154,7 @@ public class TopologyComparators {
             return false;
         }
 
-        if (o1.getSlots().size() != o2.getSlots().size() || !o1.getSlots().containsAll(o2.getSlots())) {
+        if (!o1.hasSameSlotsOf(o2)) {
             return false;
         }
 

--- a/src/test/java/io/lettuce/core/cluster/topology/TopologyComparatorsUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/topology/TopologyComparatorsUnitTests.java
@@ -20,10 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.Lists.newArrayList;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -306,6 +303,34 @@ class TopologyComparatorsUnitTests {
         Partitions partitions1 = ClusterPartitionParser.parse(nodes1);
         Partitions partitions2 = ClusterPartitionParser.parse(nodes2);
         assertThat(isChanged(partitions1, partitions2)).isTrue();
+    }
+
+    @Test
+    void aNodeShouldNotHaveSameSlotsIfOtherNodeIsNull() {
+        RedisClusterNode nodeA = createNode(3);
+        assertThat(nodeA.hasSameSlotsOf(null)).isFalse();
+    }
+
+    @Test
+    void nodesShouldHaveSameSlots() {
+        RedisClusterNode nodeA = createNode(1, 4, 36, 98);
+        RedisClusterNode nodeB = createNode(4, 36, 1, 98);
+        assertThat(nodeA.getSlots().containsAll(nodeB.getSlots())).isTrue();
+        assertThat(nodeA.hasSameSlotsOf(nodeB)).isTrue();
+    }
+
+    @Test
+    void nodesShouldNotHaveSameSlots() {
+        RedisClusterNode nodeA = createNode(1, 4, 36, 99);
+        RedisClusterNode nodeB = createNode(4, 36, 1, 100);
+        assertThat(nodeA.getSlots().containsAll(nodeB.getSlots())).isFalse();
+        assertThat(nodeA.hasSameSlotsOf(nodeB)).isFalse();
+    }
+
+    private RedisClusterNode createNode(Integer ... slots) {
+        RedisClusterNode node = new RedisClusterNode();
+        node.setSlots(Arrays.asList(slots));
+        return node;
     }
 
     @Test


### PR DESCRIPTION
This PR is related to the issue #1011.

**What**

Added the `hasSameSlotsOf` method to the `RedisClusterNode` class so it can be used by the `TopologyComparators` class while is comparing the node slots.
Added unit tests to verify the behaviour of the new method.

**Why**
Solve the performance issue #1011 