### PR TITLE
Remove mget collect

### DIFF
--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -262,6 +262,9 @@ public interface RedisStringReactiveCommands<K, V> {
 
     /**
      * Get the values of all the given keys.
+     * <p>
+     * Values are not guaranteed to be returned in the same order as the requested keys.
+     * </p>
      *
      * @param keys the key
      * @return V array-reply list of values at the specified keys.

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -281,31 +281,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
             publishers.add(super.mget(entry.getValue()));
         }
 
-        Flux<KeyValue<K, V>> fluxes = Flux.concat(publishers);
-
-        Mono<List<KeyValue<K, V>>> map = fluxes.collectList().map(vs -> {
-
-            KeyValue<K, V>[] values = new KeyValue[vs.size()];
-            int offset = 0;
-            for (Map.Entry<Integer, List<K>> entry : partitioned.entrySet()) {
-
-                for (int i = 0; i < keyList.size(); i++) {
-
-                    int index = entry.getValue().indexOf(keyList.get(i));
-                    if (index == -1) {
-                        continue;
-                    }
-
-                    values[i] = vs.get(offset + index);
-                }
-
-                offset += entry.getValue().size();
-            }
-
-            return Arrays.asList(values);
-        });
-
-        return map.flatMapIterable(keyValues -> keyValues);
+        return Flux.merge(publishers);
     }
 
     @Override


### PR DESCRIPTION
Implements #1116 by removing code that re-orders the returned values from clustered MGET. Clarification was also added to the MGET documentation to make it explicit that the order of the results are not guaranteed.

The publishers for each individual shard also now use Flux.merge instead of Flux.concat: https://stackoverflow.com/a/48478721/63155

- [X] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
