### PR TITLE
Remove duplicated ConnectionWatchdog

### DIFF
--- a/src/main/java/io/lettuce/core/ConnectionBuilder.java
+++ b/src/main/java/io/lettuce/core/ConnectionBuilder.java
@@ -79,10 +79,6 @@ public class ConnectionBuilder {
         handlers.add(new CommandEncoder());
         handlers.add(commandHandlerSupplier.get());
 
-        if (clientOptions.isAutoReconnect()) {
-            handlers.add(createConnectionWatchdog());
-        }
-
         handlers.add(new ConnectionEventTrigger(connectionEvents, connection, clientResources.eventBus()));
 
         if (clientOptions.isAutoReconnect()) {


### PR DESCRIPTION
In `io.lettuce.core.ConnectionBuilder#buildHandlers` these lines of codes are duplicated:

```
if (clientOptions.isAutoReconnect()) {
    handlers.add(createConnectionWatchdog());
}
```

Channel pipeline looks like this:
```
0 = "PlainChannelInitializer#0"
1 = "channelActivator"
2 = "ChannelGroupListener#0"
3 = "CommandEncoder#0"
4 = "CommandHandler#0"
5 = "ConnectionWatchdog#0"
6 = "ConnectionEventTrigger#0"
7 = "ConnectionWatchdog#1"
8 = "DefaultChannelPipeline$TailContext#0"
```

More importantly `ConnectionWatchdog#0` and `ConnectionWatchdog#1` are actually the same instance.

I can see from #335 that `ConnectionWatchdog `is better to be the last handler.
So maybe the first creation can be removed?
Or if there is a sensible explanation for this, I can write an explaining comment.


