### PR TITLE
Disable RedisURIBuilderUnitTests failing on Windows OS

### DIFF
--- a/src/test/java/io/lettuce/core/RedisURIBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisURIBuilderUnitTests.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * Unit tests for {@link RedisURI.Builder}.
@@ -241,6 +244,7 @@ class RedisURIBuilderUnitTests {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void redisSocket() throws IOException {
         File file = new File("work/socket-6479").getCanonicalFile();
         RedisURI result = RedisURI.create(RedisURI.URI_SCHEME_REDIS_SOCKET + "://" + file.getCanonicalPath());
@@ -254,6 +258,7 @@ class RedisURIBuilderUnitTests {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void redisSocketWithPassword() throws IOException {
         File file = new File("work/socket-6479").getCanonicalFile();
         RedisURI result = RedisURI.create(RedisURI.URI_SCHEME_REDIS_SOCKET + "://password@" + file.getCanonicalPath());


### PR DESCRIPTION
Add @DisabledOnOs(OS.WINDOWS) to two tests - `redisSocket` and
`redisSocketWithPassword` that fail in Windows:

```
java.lang.IllegalArgumentException: Illegal character in authority at index 15: redis-socket://C:\Users\konstantinsh\IdeaProjects\lettuce-core\work\socket-6479

	at java.base/java.net.URI.create(URI.java:883)
	at io.lettuce.core.RedisURI.create(RedisURI.java:233)
```

Tests are disabled on Windows as socket connections are not supposed
to be used on OS other that Unix.
