### PR TITLE
add auth(username,password) to allow reconnection - issue #1202

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -87,6 +87,19 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisHashAsync
     }
 
     @Override
+    public RedisFuture<String> auth(String username, CharSequence password) {
+        LettuceAssert.notNull(username, "Username must not be null");
+        LettuceAssert.notNull(password, "Password must not be null");
+        return dispatch(commandBuilder.auth(username, password));
+    }
+
+    public RedisFuture<String> auth(String username, char[] password) {
+        LettuceAssert.notNull(username, "Username must not be null");
+        LettuceAssert.notNull(password, "Password must not be null");
+        return dispatch(commandBuilder.auth(username, password));
+    }
+
+    @Override
     public RedisFuture<String> bgrewriteaof() {
         return dispatch(commandBuilder.bgrewriteaof());
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -110,6 +110,11 @@ public abstract class AbstractRedisReactiveCommands<K, V> implements RedisHashRe
     }
 
     @Override
+    public Mono<String> auth(String username, CharSequence password) {
+        return createMono(() -> commandBuilder.auth(username, password));
+    }
+
+    @Override
     public Mono<String> bgrewriteaof() {
         return createMono(commandBuilder::bgrewriteaof);
     }

--- a/src/main/java/io/lettuce/core/ConnectionState.java
+++ b/src/main/java/io/lettuce/core/ConnectionState.java
@@ -115,6 +115,10 @@ public class ConnectionState {
         return this.password != null && this.password.length > 0;
     }
 
+    boolean hasUsername() {
+        return this.username != null && !this.username.isEmpty();
+    }
+
     protected void setDb(int db) {
         this.db = db;
     }

--- a/src/main/java/io/lettuce/core/MigrateArgs.java
+++ b/src/main/java/io/lettuce/core/MigrateArgs.java
@@ -112,6 +112,7 @@ public class MigrateArgs<K> implements CompositeArgument {
          * @see MigrateArgs#auth(CharSequence)
          */
         public static <K> MigrateArgs<K> auth(CharSequence password) {
+            // TODO : implement auth(username,password) when https://github.com/antirez/redis/pull/7035 is fixed
             return new MigrateArgs<K>().auth(password);
         }
 

--- a/src/main/java/io/lettuce/core/RedisCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RedisCommandBuilder.java
@@ -81,6 +81,29 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(AUTH, new StatusOutput<>(codec), args);
     }
 
+    Command<K, V, String> auth(String username, CharSequence password) {
+        LettuceAssert.notNull(username, "Username " + MUST_NOT_BE_NULL);
+        LettuceAssert.isTrue(!username.isEmpty(), "Username " + MUST_NOT_BE_EMPTY);
+        LettuceAssert.notNull(password, "Password " + MUST_NOT_BE_NULL);
+        LettuceAssert.notEmpty(password, "Password " + MUST_NOT_BE_EMPTY);
+
+        char[] chars = new char[password.length()];
+        for (int i = 0; i < password.length(); i++) {
+            chars[i] = password.charAt(i);
+        }
+        return auth(username,chars);
+    }
+
+    Command<K, V, String> auth(String username, char[] password) {
+        LettuceAssert.notNull(username, "Username " + MUST_NOT_BE_NULL);
+        LettuceAssert.isTrue(!username.isEmpty(), "Username " + MUST_NOT_BE_EMPTY);
+        LettuceAssert.notNull(password, "Password " + MUST_NOT_BE_NULL);
+        LettuceAssert.isTrue(password.length > 0, "Password " + MUST_NOT_BE_EMPTY);
+
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(username).add(password);
+        return createCommand(AUTH, new StatusOutput<>(codec), args);
+    }
+
     Command<K, V, String> bgrewriteaof() {
         return createCommand(BGREWRITEAOF, new StatusOutput<>(codec));
     }

--- a/src/main/java/io/lettuce/core/RedisHandshake.java
+++ b/src/main/java/io/lettuce/core/RedisHandshake.java
@@ -151,8 +151,9 @@ class RedisHandshake implements ConnectionInitializer {
      * @return
      */
     private CompletableFuture<?> initiateHandshakeResp2(Channel channel) {
-
-        if (connectionState.hasPassword()) {
+        if (connectionState.hasUsername()) {
+            return dispatch(channel, this.commandBuilder.auth(connectionState.getUsername() ,connectionState.getPassword()));
+        } else if (connectionState.hasPassword()) {
             return dispatch(channel, this.commandBuilder.auth(connectionState.getPassword()));
         } else if (this.pingOnConnect) {
             return dispatch(channel, this.commandBuilder.ping());

--- a/src/main/java/io/lettuce/core/api/async/RedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisAsyncCommands.java
@@ -42,6 +42,15 @@ public interface RedisAsyncCommands<K, V> extends BaseRedisAsyncCommands<K, V>, 
     RedisFuture<String> auth(CharSequence password);
 
     /**
+     * Authenticate to the server.
+     *
+     * @param username the username
+     * @param password the password
+     * @return String simple-string-reply
+     */
+    RedisFuture<String> auth(String username, CharSequence password);
+
+    /**
      * Change the selected database for the current connection.
      *
      * @param db the database number

--- a/src/main/java/io/lettuce/core/api/reactive/RedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisReactiveCommands.java
@@ -42,6 +42,15 @@ public interface RedisReactiveCommands<K, V> extends BaseRedisReactiveCommands<K
     Mono<String> auth(CharSequence password);
 
     /**
+     * Authenticate to the server.
+     *
+     * @param username the username
+     * @param password the password
+     * @return String simple-string-reply
+     */
+    Mono<String> auth(String username, CharSequence password);
+
+    /**
      * Change the selected database for the current connection.
      *
      * @param db the database number

--- a/src/main/java/io/lettuce/core/api/sync/RedisCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisCommands.java
@@ -33,6 +33,15 @@ public interface RedisCommands<K, V> extends BaseRedisCommands<K, V>, RedisClust
         RedisStreamCommands<K, V>, RedisStringCommands<K, V>, RedisTransactionalCommands<K, V> {
 
     /**
+     * Authenticate to the server with username and password.
+     *
+     * @param username the username
+     * @param password the password
+     * @return String simple-string-reply
+     */
+    String auth(String username, CharSequence password);
+
+    /**
      * Authenticate to the server.
      *
      * @param password the password

--- a/src/main/java/io/lettuce/core/cluster/api/async/RedisClusterAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/RedisClusterAsyncCommands.java
@@ -54,6 +54,15 @@ public interface RedisClusterAsyncCommands<K, V> extends BaseRedisAsyncCommands<
     RedisFuture<String> auth(CharSequence password);
 
     /**
+     * Authenticate to the server.
+     *
+     * @param username the username
+     * @param password the password
+     * @return String simple-string-reply
+     */
+    RedisFuture<String> auth(String username, CharSequence password);
+
+    /**
      * Generate a new config epoch, incrementing the current epoch, assign the new epoch to this node, WITHOUT any consensus and
      * persist the configuration on disk before sending packets with the new configuration.
      *

--- a/src/main/java/io/lettuce/core/cluster/api/reactive/RedisClusterReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/reactive/RedisClusterReactiveCommands.java
@@ -55,6 +55,15 @@ public interface RedisClusterReactiveCommands<K, V> extends BaseRedisReactiveCom
     Mono<String> auth(CharSequence password);
 
     /**
+     * Authenticate to the server.
+     *
+     * @param username the username
+     * @param password the password
+     * @return String simple-string-reply
+     */
+    Mono<String> auth(String username, CharSequence password);
+
+    /**
      * Generate a new config epoch, incrementing the current epoch, assign the new epoch to this node, WITHOUT any consensus and
      * persist the configuration on disk before sending packets with the new configuration.
      *

--- a/src/main/java/io/lettuce/core/cluster/api/sync/RedisClusterCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/RedisClusterCommands.java
@@ -51,6 +51,15 @@ public interface RedisClusterCommands<K, V> extends BaseRedisCommands<K, V>, Red
     String auth(CharSequence password);
 
     /**
+     * Authenticate to the server.
+     *
+     * @param username the username
+     * @param password the password
+     * @return String simple-string-reply
+     */
+    String auth(String username, CharSequence password);
+
+    /**
      * Generate a new config epoch, incrementing the current epoch, assign the new epoch to this node, WITHOUT any consensus and
      * persist the configuration on disk before sending packets with the new configuration.
      *

--- a/src/test/java/io/lettuce/core/ClientOptionsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ClientOptionsIntegrationTests.java
@@ -131,6 +131,20 @@ class ClientOptionsIntegrationTests extends TestSupport {
     }
 
     @Test
+    void testHitRequestQueueLimitReconnectWithAuthUsernamePasswordCommand() {
+
+        WithPassword.run(client, () -> {
+
+            client.setOptions(ClientOptions.builder().protocolVersion(ProtocolVersion.RESP2).pingBeforeActivateConnection(false)
+                    .requestQueueSize(10).build());
+
+            RedisAsyncCommands<String, String> connection = client.connect().async();
+            connection.auth(username, passwd);
+            testHitRequestQueueLimit(connection);
+        });
+    }
+
+    @Test
     void testHitRequestQueueLimitReconnectWithUriAuth() {
 
         WithPassword.run(client, () -> {

--- a/src/test/java/io/lettuce/core/ReactiveConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ReactiveConnectionIntegrationTests.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import javax.enterprise.inject.New;
 import javax.inject.Inject;
 
+import io.lettuce.test.WithPassword;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -203,6 +204,16 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
     @Test
     void auth() {
         StepVerifier.create(reactive.auth("error")).expectError().verify();
+        StepVerifier.create(reactive.auth(username, "error")).expectNext("OK").verifyComplete();
+
+        WithPassword.enableAuthentication(  this.connection.sync());
+
+        StepVerifier.create(reactive.auth(username, "error")).expectError().verify();
+
+        StepVerifier.create(reactive.auth(sampleUsername,  samplePasswd)).expectNext("OK").verifyComplete();
+        StepVerifier.create(reactive.auth(sampleUsername,  "error")).expectError().verify();
+
+        WithPassword.disableAuthentication(  this.connection.sync());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/TestSupport.java
+++ b/src/test/java/io/lettuce/core/TestSupport.java
@@ -29,7 +29,11 @@ public abstract class TestSupport {
 
     public static final String host = TestSettings.hostAddr();
     public static final int port = TestSettings.port();
+    public static final String username = TestSettings.username();
     public static final String passwd = TestSettings.password();
+
+    public static final String sampleUsername = TestSettings.sampleUsername();
+    public static final String samplePasswd = TestSettings.samplePassword();
 
     public static final String key = "key";
     public static final String value = "value";

--- a/src/test/java/io/lettuce/core/pubsub/PubSubCommandTest.java
+++ b/src/test/java/io/lettuce/core/pubsub/PubSubCommandTest.java
@@ -98,6 +98,21 @@ class PubSubCommandTest extends AbstractRedisClientTest implements RedisPubSubLi
     }
 
     @Test
+    void authWithUsername() {
+        WithPassword.run(client, () -> {
+
+            client.setOptions(
+                    ClientOptions.builder().protocolVersion(ProtocolVersion.RESP2).pingBeforeActivateConnection(false).build());
+            RedisPubSubAsyncCommands<String, String> connection = client.connectPubSub().async();
+            connection.getStatefulConnection().addListener(PubSubCommandTest.this);
+            connection.auth(username,passwd);
+
+            connection.subscribe(channel);
+            assertThat(channels.take()).isEqualTo(channel);
+        });
+    }
+
+    @Test
     void authWithReconnect() {
 
         WithPassword.run(client, () -> {
@@ -113,7 +128,7 @@ class PubSubCommandTest extends AbstractRedisClientTest implements RedisPubSubLi
 
             assertThat(channels.take()).isEqualTo(channel);
 
-            redis.auth(passwd);
+            redis.auth(username, passwd);
             long id = findNamedClient("authWithReconnect");
             redis.clientKill(KillArgs.Builder.id(id));
 

--- a/src/test/java/io/lettuce/examples/ConnectToRedis.java
+++ b/src/test/java/io/lettuce/examples/ConnectToRedis.java
@@ -26,6 +26,7 @@ public class ConnectToRedis {
     public static void main(String[] args) {
 
         // Syntax: redis://[password@]host[:port][/databaseNumber]
+        // Syntax: redis://[username:password@]host[:port][/databaseNumber]
         RedisClient redisClient = RedisClient.create("redis://password@localhost:6379/0");
         StatefulRedisConnection<String, String> connection = redisClient.connect();
 

--- a/src/test/java/io/lettuce/examples/ConnectToRedisCluster.java
+++ b/src/test/java/io/lettuce/examples/ConnectToRedisCluster.java
@@ -26,6 +26,7 @@ public class ConnectToRedisCluster {
     public static void main(String[] args) {
 
         // Syntax: redis://[password@]host[:port]
+        // Syntax: redis://[username:password@]host[:port]
         RedisClusterClient redisClient = RedisClusterClient.create("redis://password@localhost:7379");
 
         StatefulRedisClusterConnection<String, String> connection = redisClient.connect();

--- a/src/test/java/io/lettuce/test/settings/TestSettings.java
+++ b/src/test/java/io/lettuce/test/settings/TestSettings.java
@@ -75,6 +75,15 @@ public class TestSettings {
         }
     }
 
+
+    /**
+     *
+     * @return default username of your redis instance.
+     */
+    public static String username() {
+        return "default";
+    }
+
     /**
      *
      * @return password of your redis instance. Defaults to {@literal passwd}. Can be overridden with
@@ -82,6 +91,24 @@ public class TestSettings {
      */
     public static String password() {
         return System.getProperty("password", "passwd");
+    }
+
+    /**
+     *
+     * @return password of a second user your redis instance. Defaults to {@literal lettuceTest}. Can be overridden with
+     *         {@code --Dsample.username=SampleUsername}
+     */
+    public static String sampleUsername() {
+        return System.getProperty("sample.username", "lettuceTest");
+    }
+
+    /**
+     *
+     * @return password of a second user of your redis instance. Defaults to {@literal lettuceTestPasswd}. Can be overridden with
+     *         {@code -Dsample.password=SamplePassword}
+     */
+    public static String samplePassword() {
+        return System.getProperty("sample.password", "lettuceTestPasswd");
     }
 
     /**


### PR DESCRIPTION

* From my understanding of Lettuce core I have implemented all methods
* The only one that is still missing is the `migrate()` command that does not yet support u/p in Redis (see [7034](https://github.com/antirez/redis/issues/7034) )

---------

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request. (#1202)
- [X] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.





