### PR TITLE
[hotfix] set tracing interface method includeCommandArgsInSpanTags as…

### DIFF
--- a/src/main/java/io/lettuce/core/tracing/Tracing.java
+++ b/src/main/java/io/lettuce/core/tracing/Tracing.java
@@ -51,12 +51,15 @@ public interface Tracing {
     boolean isEnabled();
 
     /**
+     * Set it as a default method can  avoid java.lang.AbstractMethodError caused by version upgrade.
      * Returns {@literal true} if tags for {@link Tracer.Span}s should include the command arguments.
      *
      * @return {@literal true} if tags for {@link Tracer.Span}s should include the command arguments.
      * @since 5.2
      */
-    boolean includeCommandArgsInSpanTags();
+    default boolean includeCommandArgsInSpanTags(){
+        return false;
+    }
 
     /**
      * Create an {@link Endpoint} given {@link SocketAddress}.


### PR DESCRIPTION
… a default method

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/master/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

I am an apm system developer. In order to avoid jar package conflicts as much as possible, the lettuce package is an optional dependency when building in maven, because the developer will indirectly rely on it in the form of spring boot starter. 

At present, the apm system is developed based on spring boot 2.1.16, but recently when developers upgraded the spring boot version to 2.2.6, because the implementation of the Tracing interface reported an error, I think that although the spring boot version is inconsistent (this is in It's a common thing between the business side and the architect side), and it can be avoided.