### PR TITLE
Add basic native-image configuration

### DIFF
--- a/src/main/resources/META-INF/native-image/native-image.properties
+++ b/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=io.lettuce.core.metrics.DefaultCommandLatencyCollector

--- a/src/main/resources/META-INF/native-image/proxy-config.json
+++ b/src/main/resources/META-INF/native-image/proxy-config.json
@@ -1,0 +1,3 @@
+[
+  ["io.lettuce.core.api.sync.RedisCommands","io.lettuce.core.cluster.api.sync.RedisClusterCommands"]
+]

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,233 @@
+[
+  {
+    "name":"io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+    "fields":[{"name":"producerLimit","allowUnsafeAccess" :  true}]
+  },
+  {
+    "name":"io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+    "fields":[{"name":"consumerIndex","allowUnsafeAccess" :  true}]
+  },
+  {
+    "name":"io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+    "fields":[{"name":"producerIndex", "allowUnsafeAccess" :  true}]
+  },
+  {
+    "name":"io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+    "fields":[{"name":"consumerIndex", "allowUnsafeAccess" :  true}]
+  },
+  {
+    "name":"io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+    "fields":[{"name":"producerIndex", "allowUnsafeAccess" :  true}]
+  },
+  {
+    "name":"io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+    "fields":[{"name":"producerLimit","allowUnsafeAccess" :  true}]
+  },
+  {
+    "name":"java.nio.Buffer",
+    "fields":[{"name":"address", "allowUnsafeAccess":true}]
+  },
+  {
+    "name":"java.nio.DirectByteBuffer",
+    "fields":[{"name":"cleaner", "allowUnsafeAccess":true}],
+    "methods":[{"name":"<init>","parameterTypes":["long","int"] }]
+  },
+  {
+    "name":"io.netty.buffer.AbstractReferenceCountedByteBuf",
+    "fields":[{"name":"refCnt", "allowUnsafeAccess":true}]
+  },
+  {
+    "name": "io.lettuce.core.AbstractRedisAsyncCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.ChannelGroupListener",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.ConnectionEventTrigger",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.PlainChannelInitializer$1",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.RedisAsyncCommandsImpl",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.RedisClient",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.BaseRedisCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisGeoCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisHLLCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisHashCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisKeyCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisListCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisScriptingCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisServerCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisSetCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisSortedSetCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisStreamCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisStringCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.api.sync.RedisTransactionalCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+
+  {
+    "name":"io.lettuce.core.cluster.api.sync.RedisClusterCommands",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+
+  {
+    "name":"io.lettuce.core.protocol.CommandHandler",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.lettuce.core.protocol.ConnectionWatchdog",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+
+  {
+    "name":"io.lettuce.core.resource.ClientResources",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+
+  {
+    "name":"io.lettuce.core.resource.DefaultClientResources",
+    "allDeclaredFields" : true,
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.netty.buffer.AbstractByteBufAllocator",
+    "allPublicMethods": true,
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.netty.buffer.PooledByteBufAllocator",
+    "allPublicMethods": true,
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.netty.channel.ChannelDuplexHandler",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.netty.channel.ChannelHandlerAdapter",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.channel.ChannelInitializer",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.channel.ChannelOutboundHandlerAdapter",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.channel.DefaultChannelPipeline$HeadContext",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.channel.DefaultChannelPipeline$TailContext",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.channel.socket.nio.NioSocketChannel",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToByteEncoder",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name":"io.netty.util.ReferenceCountUtil",
+    "allPublicMethods": true,
+    "allDeclaredConstructors":true
+  }
+]


### PR DESCRIPTION
A starting point for further improvements. 

Add required `proxy-config` and `reflect-config` including netty setup allowing unsafe access to certain fields. 
Also register `DefaultCommandLatencyCollector` for build time initialization.

Relates to: #1316 