### PR TITLE
Add SSL handshake timeout in SslOptions

### DIFF
--- a/src/main/java/io/lettuce/core/SslConnectionBuilder.java
+++ b/src/main/java/io/lettuce/core/SslConnectionBuilder.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -112,6 +113,10 @@ public class SslConnectionBuilder extends ConnectionBuilder {
 
             SSLEngine sslEngine = initializeSSLEngine(channel.alloc());
             SslHandler sslHandler = new SslHandler(sslEngine, startTls);
+            Duration sslHandshakeTimeout = sslOptions.getSslHandshakeTimeout();
+            if (sslHandshakeTimeout != null) {
+                sslHandler.setHandshakeTimeoutMillis(sslHandshakeTimeout.toMillis());
+            }
             channel.pipeline().addLast(sslHandler);
 
             for (ChannelHandler handler : handlers.get()) {

--- a/src/main/java/io/lettuce/core/SslOptions.java
+++ b/src/main/java/io/lettuce/core/SslOptions.java
@@ -25,6 +25,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -74,6 +75,8 @@ public class SslOptions {
 
     private final KeystoreAction trustmanager;
 
+    private final Duration sslHandshakeTimeout;
+
     protected SslOptions(Builder builder) {
         this.keyStoreType = builder.keyStoreType;
         this.sslProvider = builder.sslProvider;
@@ -89,6 +92,7 @@ public class SslOptions {
         this.sslParametersSupplier = builder.sslParametersSupplier;
         this.keymanager = builder.keymanager;
         this.trustmanager = builder.trustmanager;
+        this.sslHandshakeTimeout = builder.sslHandshakeTimeout;
     }
 
     protected SslOptions(SslOptions original) {
@@ -106,6 +110,7 @@ public class SslOptions {
         this.sslParametersSupplier = original.sslParametersSupplier;
         this.keymanager = original.keymanager;
         this.trustmanager = original.trustmanager;
+        this.sslHandshakeTimeout = original.sslHandshakeTimeout;
     }
 
     /**
@@ -166,6 +171,8 @@ public class SslOptions {
         private KeystoreAction keymanager = KeystoreAction.NO_OP;
 
         private KeystoreAction trustmanager = KeystoreAction.NO_OP;
+
+        private Duration sslHandshakeTimeout = null;
 
         private Builder() {
         }
@@ -580,6 +587,18 @@ public class SslOptions {
         }
 
         /**
+         * Sets a timeout for the SSL handshake.
+         *
+         * @param timeout {@link Duration}.
+         * @return {@code this}
+         */
+        public Builder sslHandshakeTimeout(Duration timeout) {
+
+            this.sslHandshakeTimeout = timeout;
+            return this;
+        }
+
+        /**
          * Create a new instance of {@link SslOptions}
          *
          * @return new instance of {@link SslOptions}
@@ -664,6 +683,7 @@ public class SslOptions {
         builder.sslParametersSupplier = this.sslParametersSupplier;
         builder.keymanager = this.keymanager;
         builder.trustmanager = this.trustmanager;
+        builder.sslHandshakeTimeout = this.sslHandshakeTimeout;
 
         return builder;
     }
@@ -724,6 +744,13 @@ public class SslOptions {
     @Deprecated
     public char[] getTruststorePassword() {
         return Arrays.copyOf(truststorePassword, truststorePassword.length);
+    }
+
+    /**
+     * @return the SSL handshake timeout
+     */
+    public Duration getSslHandshakeTimeout() {
+        return sslHandshakeTimeout;
     }
 
     private static KeyManagerFactory createKeyManagerFactory(InputStream inputStream, char[] storePassword, String keyStoreType)


### PR DESCRIPTION
Lettuce currently uses Netty's default timeout of 10 seconds and, while changing it is possible with some finagling, this adds an easier way of setting that value to whatever you heart desires.

I couldn't get the tests to run successfully on the base without my changes, because of that I didn't add any tests.

Closes #1326.