### PR TITLE
Add flushallAsync as a cluster-level command

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
@@ -209,6 +209,11 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
     }
 
     @Override
+    public RedisFuture<String> flushallAsync() {
+        return MultiNodeExecution.firstOfAsync(executeOnUpstream(RedisServerAsyncCommands::flushallAsync));
+    }
+
+    @Override
     public RedisFuture<String> flushdb() {
         return MultiNodeExecution.firstOfAsync(executeOnUpstream(RedisServerAsyncCommands::flushdb));
     }

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -199,6 +199,13 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
     }
 
     @Override
+    public Mono<String> flushallAsync() {
+
+        Map<String, Publisher<String>> publishers = executeOnUpstream(RedisServerReactiveCommands::flushallAsync);
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
     public Mono<String> flushdb() {
 
         Map<String, Publisher<String>> publishers = executeOnUpstream(RedisServerReactiveCommands::flushdb);

--- a/src/main/java/io/lettuce/core/cluster/api/async/RedisAdvancedClusterAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/RedisAdvancedClusterAsyncCommands.java
@@ -246,6 +246,14 @@ public interface RedisAdvancedClusterAsyncCommands<K, V> extends RedisClusterAsy
     RedisFuture<String> flushall();
 
     /**
+     * Remove all keys asynchronously from all databases on all cluster upstream nodes with pipelining.
+     *
+     * @return String simple-string-reply
+     * @see RedisServerAsyncCommands#flushallAsync()
+     */
+    RedisFuture<String> flushallAsync();
+
+    /**
      * Remove all keys from the current database on all cluster upstream nodes with pipelining.
      *
      * @return String simple-string-reply

--- a/src/main/java/io/lettuce/core/cluster/api/reactive/RedisAdvancedClusterReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/reactive/RedisAdvancedClusterReactiveCommands.java
@@ -141,6 +141,14 @@ public interface RedisAdvancedClusterReactiveCommands<K, V> extends RedisCluster
     Mono<String> flushall();
 
     /**
+     * Remove all keys asynchronously from all databases on all cluster upstream nodes with pipelining.
+     *
+     * @return String simple-string-reply
+     * @see RedisServerReactiveCommands#flushallAsync()
+     */
+    Mono<String> flushallAsync();
+
+    /**
      * Remove all keys from the current database on all cluster masters with pipelining.
      *
      * @return String simple-string-reply

--- a/src/main/java/io/lettuce/core/cluster/api/sync/RedisAdvancedClusterCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/RedisAdvancedClusterCommands.java
@@ -245,6 +245,14 @@ public interface RedisAdvancedClusterCommands<K, V> extends RedisClusterCommands
     String flushall();
 
     /**
+     * Remove all keys asynchronously from all databases on all cluster upstream nodes with pipelining.
+     *
+     * @return String simple-string-reply
+     * @see RedisServerCommands#flushallAsync()
+     */
+    String flushallAsync();
+
+    /**
      * Remove all keys from the current database on all cluster upstream nodes with pipelining.
      *
      * @return String simple-string-reply

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
@@ -19,6 +19,7 @@ import static io.lettuce.test.LettuceExtension.Connection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -337,6 +338,24 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
 
         Long dbsize = sync.dbsize();
         assertThat(dbsize).isEqualTo(0);
+    }
+
+    @Test
+    void flushallAsync() throws InterruptedException {
+
+        writeKeysToTwoNodes();
+
+        assertThat(sync.flushallAsync()).isEqualTo("OK");
+
+        // This is hacky, but by its nature FLUSHALL ASYNC doesn't give us a mechanism to know when it's done
+        boolean bothKeysCleared = false;
+        final Instant deadline = Instant.now().plusSeconds(1);
+
+        while (!bothKeysCleared && Instant.now().isBefore(deadline)) {
+            bothKeysCleared = sync.get(KEY_ON_NODE_1) == null && sync.get(KEY_ON_NODE_2) == null;
+        }
+
+        assertThat(bothKeysCleared).isTrue();
     }
 
     @Test


### PR DESCRIPTION
This (eventually) closes #1359 by introducing `flushallAsync` as a cluster-level command. This is a draft and I know there are a couple big things I still need to address.

In particular:

1. I'm struggling to figure our where any of the methods in `RedisAdvancedClusterCommands` are actually implemented, and would certainly appreciate a hint there.
2. I'm having some trouble getting tests to run locally, and haven't yet found documentation explaining how to get started. I'd also welcome a hint here.

Thanks!