### PR TITLE
get redis uri from client

### DIFF
--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -604,6 +604,15 @@ public class RedisClient extends AbstractRedisClient {
         super.setOptions(clientOptions);
     }
 
+    /**
+     * Returns the {@link RedisURI} which are valid for that client
+     *
+     * @return the {@link RedisURI} for this client
+     */
+    public RedisURI getRedisURI() {
+        return redisURI;
+    }
+
     // -------------------------------------------------------------------------
     // Implementation hooks and helper methods
     // -------------------------------------------------------------------------


### PR DESCRIPTION
It would be useful to have the possibility to get RedisURI from an existing client. 

For example, you need to create an optional MasterReplicaConnection from the client, and you have to pass RedisURI again.
```kt
fun RedisClient.createConnection(
        readFrom: ReadFrom,
        redisURI: RedisURI
): StatefulRedisConnection<String, String> {
    return when (redisURI.sentinelMasterId) {
        null -> this.connect()
        else -> MasterReplica.connect(this, StringCodec.UTF8, redisURI).apply {
            this.readFrom = readFrom
        }
    }
}
```

Instead of just getting it from the client: 
```kt
fun RedisClient.createConnection(
        readFrom: ReadFrom
): StatefulRedisConnection<String, String> {
    return when (redisURI.sentinelMasterId) {
        null -> this.connect()
        else -> MasterReplica.connect(this, StringCodec.UTF8, this.redisURI).apply {
            this.readFrom = readFrom
        }
    }
}
```

Thanks!