### PR TITLE
Add support for aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>2.0.30.Final</version>
+            <version>2.0.33.Final</version>
             <classifier>${os.detected.classifier}</classifier>
             <optional>true</optional>
         </dependency>
@@ -691,6 +691,17 @@
     </build>
 
     <profiles>
+
+        <profile>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <os.detected.classifier>linux-aarch64-fedora</os.detected.classifier>
+            </properties>
+        </profile>
 
         <profile>
             <id>ci</id>


### PR DESCRIPTION
### Motivation
Fixed the build issue on aarch64. Previously build of lettuce-core was failing on aarch64 with below error: 
`[ERROR] Failed to execute goal on project lettuce-core: Could not resolve dependencies for project io.lettuce:lettuce-core:jar:6.0.0.BUILD-SNAPSHOT: Failure to find io.netty:netty-tcnative:jar:linux-aarch_64:2.0.31.Final in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]`

### Modifications
- Update netty-tcnative to 2.0.33.Final which includes aarch64 jar
- Add profile to set classifier for aarch64 in pom.xml

