### PR TITLE
Resolve hostnames using netty's non-blocking DNS resolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,11 +156,6 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
         </dependency>
 
@@ -207,6 +202,12 @@
             <artifactId>netty-tcnative</artifactId>
             <version>2.0.34.Final</version>
             <classifier>${os.detected.classifier}</classifier>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
 
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
         </dependency>
 

--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -54,9 +54,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.resolver.dns.DnsAddressResolverGroup;
-import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.internal.logging.InternalLogger;
@@ -306,9 +303,7 @@ public abstract class AbstractRedisClient {
         LettuceAssert.notNull(connectionPoint, "ConnectionPoint must not be null");
 
         if (connectionPoint.getSocket() == null) {
-            connectionBuilder.bootstrap().resolver(
-                    new DnsAddressResolverGroup(new DnsNameResolverBuilder().channelType(Transports.datagramChannelClass())
-                            .socketChannelType(Transports.socketChannelClass().asSubclass(SocketChannel.class))));
+            connectionBuilder.bootstrap().resolver(clientResources.addressResolverGroup());
         }
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -54,6 +54,9 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.internal.logging.InternalLogger;
@@ -73,6 +76,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @author Mark Paluch
  * @author Jongyeol Choi
  * @author Poorva Gokhale
+ * @author Yohei Ueki
  * @since 3.0
  * @see ClientResources
  */
@@ -294,6 +298,17 @@ public abstract class AbstractRedisClient {
             connectionBuilder.bootstrap().channel(NativeTransports.domainSocketChannelClass());
         } else {
             connectionBuilder.bootstrap().channel(Transports.socketChannelClass());
+        }
+    }
+
+    protected void resolver(ConnectionBuilder connectionBuilder, ConnectionPoint connectionPoint) {
+
+        LettuceAssert.notNull(connectionPoint, "ConnectionPoint must not be null");
+
+        if (connectionPoint.getSocket() == null) {
+            connectionBuilder.bootstrap().resolver(
+                    new DnsAddressResolverGroup(new DnsNameResolverBuilder().channelType(Transports.datagramChannelClass())
+                            .socketChannelType(Transports.socketChannelClass().asSubclass(SocketChannel.class))));
         }
     }
 

--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -75,6 +75,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  *
  * @author Will Glozer
  * @author Mark Paluch
+ * @author Yohei Ueki
  * @see RedisURI
  * @see StatefulRedisConnection
  * @see RedisFuture
@@ -322,6 +323,7 @@ public class RedisClient extends AbstractRedisClient {
         connectionBuilder(getSocketAddressSupplier(redisURI), connectionBuilder, redisURI);
         connectionBuilder.connectionInitializer(createHandshake(state));
         channelType(connectionBuilder, redisURI);
+        resolver(connectionBuilder, redisURI);
 
         ConnectionFuture<RedisChannelHandler<K, V>> future = initializeChannelAsync(connectionBuilder);
 
@@ -599,6 +601,7 @@ public class RedisClient extends AbstractRedisClient {
         connectionBuilder(getSocketAddressSupplier(redisURI), connectionBuilder, redisURI);
 
         channelType(connectionBuilder, redisURI);
+        resolver(connectionBuilder, redisURI);
         ConnectionFuture<?> sync = initializeChannelAsync(connectionBuilder);
 
         return sync.thenApply(ignore -> (StatefulRedisSentinelConnection<K, V>) connection).whenComplete((ignore, e) -> {

--- a/src/main/java/io/lettuce/core/Transports.java
+++ b/src/main/java/io/lettuce/core/Transports.java
@@ -34,7 +34,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
  * @author Yohei Ueki
  * @since 4.4
  */
-class Transports {
+public class Transports {
 
     /**
      * @return the default {@link EventLoopGroup} for socket transport that is compatible with {@link #socketChannelClass()}.
@@ -51,7 +51,7 @@ class Transports {
     /**
      * @return the default {@link Channel} for socket (network/TCP) transport.
      */
-    static Class<? extends Channel> socketChannelClass() {
+    public static Class<? extends Channel> socketChannelClass() {
 
         if (NativeTransports.isSocketSupported()) {
             return NativeTransports.socketChannelClass();
@@ -63,7 +63,7 @@ class Transports {
     /**
      * @return the default {@link DatagramChannel} for socket (network/UDP) transport.
      */
-    static Class<? extends DatagramChannel> datagramChannelClass() {
+    public static Class<? extends DatagramChannel> datagramChannelClass() {
 
         if (NativeTransports.isSocketSupported()) {
             return NativeTransports.datagramChannelClass();

--- a/src/main/java/io/lettuce/core/Transports.java
+++ b/src/main/java/io/lettuce/core/Transports.java
@@ -22,6 +22,8 @@ import io.lettuce.core.resource.KqueueProvider;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 
 /**
@@ -29,6 +31,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
  * native socket transports.
  *
  * @author Mark Paluch
+ * @author Yohei Ueki
  * @since 4.4
  */
 class Transports {
@@ -58,6 +61,18 @@ class Transports {
     }
 
     /**
+     * @return the default {@link DatagramChannel} for socket (network/UDP) transport.
+     */
+    static Class<? extends DatagramChannel> datagramChannelClass() {
+
+        if (NativeTransports.isSocketSupported()) {
+            return NativeTransports.datagramChannelClass();
+        }
+
+        return NioDatagramChannel.class;
+    }
+
+    /**
      * Native transport support.
      */
     static class NativeTransports {
@@ -77,6 +92,13 @@ class Transports {
          */
         static Class<? extends Channel> socketChannelClass() {
             return RESOURCES.socketChannelClass();
+        }
+
+        /**
+         * @return the native transport socket {@link DatagramChannel} class.
+         */
+        static Class<? extends DatagramChannel> datagramChannelClass() {
+            return RESOURCES.datagramChannelClass();
         }
 
         /**

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -135,6 +135,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * possible.
  *
  * @author Mark Paluch
+ * @author Yohei Ueki
  * @since 3.0
  * @see RedisURI
  * @see StatefulRedisClusterConnection
@@ -815,6 +816,7 @@ public class RedisClusterClient extends AbstractRedisClient {
         connectionBuilder.commandHandler(commandHandlerSupplier);
         connectionBuilder(socketAddressSupplier, connectionBuilder, connectionSettings);
         channelType(connectionBuilder, connectionSettings);
+        resolver(connectionBuilder, connectionSettings);
 
         return connectionBuilder;
     }

--- a/src/main/java/io/lettuce/core/resource/AddressResolverGroupProvider.java
+++ b/src/main/java/io/lettuce/core/resource/AddressResolverGroupProvider.java
@@ -1,0 +1,65 @@
+package io.lettuce.core.resource;
+
+import java.util.function.Supplier;
+
+import io.lettuce.core.Transports;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * Wraps and provides {@link AddressResolverGroup} classes. This is to protect the user from {@link ClassNotFoundException}'s
+ * caused by the absence of the {@literal netty-dns-resolver} library during runtime. This class will be deleted when
+ * {@literal netty-dns-resolver} becomes mandatory. Internal API.
+ *
+ * @author Yohei Ueki
+ * @since xxx
+ */
+class AddressResolverGroupProvider {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AddressResolverGroupProvider.class);
+
+    private static final AddressResolverGroup<?> ADDRESS_RESOLVER_GROUP;
+
+    static {
+        boolean dnsResolverAvailable;
+        try {
+            Class.forName("io.netty.resolver.dns.DnsAddressResolverGroup");
+            dnsResolverAvailable = true;
+        } catch (ClassNotFoundException e) {
+            dnsResolverAvailable = false;
+        }
+
+        // create addressResolverGroup instance via Supplier to avoid NoClassDefFoundError.
+        Supplier<AddressResolverGroup<?>> supplier;
+        if (dnsResolverAvailable) {
+            logger.debug("Starting with netty's non-blocking DNS resolver library");
+            supplier = AddressResolverGroupProvider::defaultDnsAddressResolverGroup;
+        } else {
+            logger.debug("Starting without optional netty's non-blocking DNS resolver library");
+            supplier = () -> DefaultAddressResolverGroup.INSTANCE;
+        }
+        ADDRESS_RESOLVER_GROUP = supplier.get();
+    }
+
+    /**
+     * Returns the {@link AddressResolverGroup} for dns resolution.
+     *
+     * @return the {@link DnsAddressResolverGroup} if {@literal netty-dns-resolver} is available, otherwise return
+     *         {@link DefaultAddressResolverGroup#INSTANCE}.
+     * @since xxx
+     */
+    static AddressResolverGroup<?> addressResolverGroup() {
+        return ADDRESS_RESOLVER_GROUP;
+    }
+
+    private static DnsAddressResolverGroup defaultDnsAddressResolverGroup() {
+        return new DnsAddressResolverGroup(new DnsNameResolverBuilder().channelType(Transports.datagramChannelClass())
+                .socketChannelType(Transports.socketChannelClass().asSubclass(SocketChannel.class)));
+    }
+
+}

--- a/src/main/java/io/lettuce/core/resource/ClientResources.java
+++ b/src/main/java/io/lettuce/core/resource/ClientResources.java
@@ -24,6 +24,7 @@ import io.lettuce.core.metrics.CommandLatencyCollector;
 import io.lettuce.core.metrics.CommandLatencyCollectorOptions;
 import io.lettuce.core.metrics.CommandLatencyRecorder;
 import io.lettuce.core.tracing.Tracing;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
@@ -45,10 +46,12 @@ import io.netty.util.concurrent.Future;
  * <li>{@link DnsResolver} to collect latency details. Requires the {@literal LatencyUtils} library.</li>
  * <li>{@link Timer} for scheduling</li>
  * <li>{@link Tracing} to trace Redis commands.</li>
+ * <li>{@link AddressResolverGroup} for dns resolution.</li>
  * </ul>
  *
  * @author Mark Paluch
  * @author Mikhael Sokolov
+ * @author Yohei Ueki
  * @since 3.4
  * @see DefaultClientResources
  */
@@ -242,6 +245,18 @@ public interface ClientResources {
         Builder tracing(Tracing tracing);
 
         /**
+         * Sets the {@link AddressResolverGroup} for dns resolution. This option is only effective if
+         * {@link DnsResolvers#UNRESOLVED} is used as {@link DnsResolver}. Defaults to
+         * {@link io.netty.resolver.DefaultAddressResolverGroup#INSTANCE} if {@literal netty-dns-resolver} is not available,
+         * otherwise defaults to {@link io.netty.resolver.dns.DnsAddressResolverGroup}.
+         *
+         * @param addressResolverGroup the {@link AddressResolverGroup} instance, must not be {@code null}.
+         * @return {@code this} {@link Builder}
+         * @since xxx
+         */
+        Builder addressResolverGroup(AddressResolverGroup<?> addressResolverGroup);
+
+        /**
          * @return a new instance of {@link DefaultClientResources}.
          */
         ClientResources build();
@@ -384,5 +399,13 @@ public interface ClientResources {
      * @since 5.1
      */
     Tracing tracing();
+
+    /**
+     * Return the {@link AddressResolverGroup} instance for dns resolution.
+     *
+     * @return the address resolver group.
+     * @since xxx
+     */
+    AddressResolverGroup<?> addressResolverGroup();
 
 }

--- a/src/main/java/io/lettuce/core/resource/EpollProvider.java
+++ b/src/main/java/io/lettuce/core/resource/EpollProvider.java
@@ -22,9 +22,11 @@ import io.lettuce.core.internal.LettuceAssert;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -36,6 +38,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * the {@literal netty-transport-native-epoll} library during runtime. Internal API.
  *
  * @author Mark Paluch
+ * @author Yohei Ueki
  * @since 4.4
  */
 public class EpollProvider {
@@ -153,6 +156,13 @@ public class EpollProvider {
             return null;
         }
 
+        @Override
+        public Class<? extends DatagramChannel> datagramChannelClass() {
+
+            checkForEpollLibrary();
+            return null;
+        }
+
     }
 
     /**
@@ -192,6 +202,14 @@ public class EpollProvider {
             checkForEpollLibrary();
 
             return EpollSocketChannel.class;
+        }
+
+        @Override
+        public Class<? extends DatagramChannel> datagramChannelClass() {
+
+            checkForEpollLibrary();
+
+            return EpollDatagramChannel.class;
         }
 
         @Override

--- a/src/main/java/io/lettuce/core/resource/EventLoopResources.java
+++ b/src/main/java/io/lettuce/core/resource/EventLoopResources.java
@@ -21,12 +21,14 @@ import java.util.concurrent.ThreadFactory;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
 import io.netty.util.concurrent.EventExecutorGroup;
 
 /**
  * Interface to encapsulate EventLoopGroup resources.
  *
  * @author Mark Paluch
+ * @author Yohei Ueki
  * @since 6.0
  */
 public interface EventLoopResources {
@@ -57,6 +59,11 @@ public interface EventLoopResources {
      * @return the {@link Channel} class.
      */
     Class<? extends Channel> socketChannelClass();
+
+    /**
+     * @return the {@link DatagramChannel} class.
+     */
+    Class<? extends DatagramChannel> datagramChannelClass();
 
     /**
      * @return the {@link EventLoopGroup} class.

--- a/src/main/java/io/lettuce/core/resource/KqueueProvider.java
+++ b/src/main/java/io/lettuce/core/resource/KqueueProvider.java
@@ -22,9 +22,11 @@ import io.lettuce.core.internal.LettuceAssert;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -36,6 +38,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * the {@literal netty-transport-native-kqueue} library during runtime. Internal API.
  *
  * @author Mark Paluch
+ * @author Yohei Ueki
  * @since 4.4
  */
 public class KqueueProvider {
@@ -153,6 +156,15 @@ public class KqueueProvider {
             return null;
         }
 
+        @Override
+        public Class<? extends DatagramChannel> datagramChannelClass() {
+
+
+            checkForKqueueLibrary();
+            return null;
+        }
+
+
     }
 
     /**
@@ -193,6 +205,15 @@ public class KqueueProvider {
 
             return KQueueSocketChannel.class;
         }
+
+        @Override
+        public Class<? extends DatagramChannel> datagramChannelClass() {
+
+            checkForKqueueLibrary();
+
+            return KQueueDatagramChannel.class;
+        }
+
 
         @Override
         public Class<? extends EventLoopGroup> eventLoopGroupClass() {

--- a/src/test/java/io/lettuce/core/resource/DefaultClientResourcesUnitTests.java
+++ b/src/test/java/io/lettuce/core/resource/DefaultClientResourcesUnitTests.java
@@ -30,6 +30,7 @@ import io.lettuce.core.metrics.DefaultCommandLatencyCollectorOptions;
 import io.lettuce.test.TestFutures;
 import io.lettuce.test.resource.FastShutdown;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -39,6 +40,7 @@ import io.netty.util.concurrent.Future;
  * Unit tests for {@link DefaultClientResources}.
  *
  * @author Mark Paluch
+ * @author Yohei Ueki
  */
 class DefaultClientResourcesUnitTests {
 
@@ -108,16 +110,19 @@ class DefaultClientResourcesUnitTests {
         EventBus eventBusMock = mock(EventBus.class);
         CommandLatencyCollector latencyCollectorMock = mock(CommandLatencyCollector.class);
         NettyCustomizer nettyCustomizer = mock(NettyCustomizer.class);
+        AddressResolverGroup<?> addressResolverGroup = mock(AddressResolverGroup.class);
 
         DefaultClientResources sut = DefaultClientResources.builder().eventExecutorGroup(executorMock)
                 .eventLoopGroupProvider(groupProviderMock).timer(timerMock).eventBus(eventBusMock)
-                .commandLatencyRecorder(latencyCollectorMock).nettyCustomizer(nettyCustomizer).build();
+                .commandLatencyRecorder(latencyCollectorMock).nettyCustomizer(nettyCustomizer)
+                .addressResolverGroup(addressResolverGroup).build();
 
         assertThat(sut.eventExecutorGroup()).isSameAs(executorMock);
         assertThat(sut.eventLoopGroupProvider()).isSameAs(groupProviderMock);
         assertThat(sut.timer()).isSameAs(timerMock);
         assertThat(sut.eventBus()).isSameAs(eventBusMock);
         assertThat(sut.nettyCustomizer()).isSameAs(nettyCustomizer);
+        assertThat(sut.addressResolverGroup()).isSameAs(addressResolverGroup);
 
         assertThat(TestFutures.getOrTimeout(sut.shutdown())).isTrue();
 
@@ -137,11 +142,11 @@ class DefaultClientResourcesUnitTests {
         Timer timerMock2 = mock(Timer.class);
         EventBus eventBusMock = mock(EventBus.class);
         CommandLatencyCollector latencyCollectorMock = mock(CommandLatencyCollector.class);
-
+        AddressResolverGroup<?> addressResolverGroupMock = mock(AddressResolverGroup.class);
 
         ClientResources sut = ClientResources.builder().eventExecutorGroup(executorMock)
                 .eventLoopGroupProvider(groupProviderMock).timer(timerMock).eventBus(eventBusMock)
-                .commandLatencyRecorder(latencyCollectorMock).build();
+                .commandLatencyRecorder(latencyCollectorMock).addressResolverGroup(addressResolverGroupMock).build();
 
         ClientResources copy = sut.mutate().timer(timerMock2).build();
 
@@ -151,6 +156,7 @@ class DefaultClientResourcesUnitTests {
         assertThat(sut.timer()).isSameAs(timerMock);
         assertThat(copy.timer()).isSameAs(timerMock2).isNotSameAs(timerMock);
         assertThat(sut.eventBus()).isSameAs(eventBusMock);
+        assertThat(sut.addressResolverGroup()).isSameAs(addressResolverGroupMock);
 
         assertThat(TestFutures.getOrTimeout(sut.shutdown())).isTrue();
 

--- a/src/test/jmh/io/lettuce/core/protocol/EmptyClientResources.java
+++ b/src/test/jmh/io/lettuce/core/protocol/EmptyClientResources.java
@@ -28,6 +28,7 @@ import io.lettuce.core.metrics.CommandLatencyRecorder;
 import io.lettuce.core.metrics.CommandMetrics;
 import io.lettuce.core.resource.*;
 import io.lettuce.core.tracing.Tracing;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
@@ -36,6 +37,7 @@ import io.netty.util.concurrent.SucceededFuture;
 
 /**
  * @author Mark Paluch
+ * @author Yohei Ueki
  */
 public class EmptyClientResources implements ClientResources {
 
@@ -121,6 +123,11 @@ public class EmptyClientResources implements ClientResources {
     @Override
     public Tracing tracing() {
         return Tracing.disabled();
+    }
+
+    @Override
+    public AddressResolverGroup<?> addressResolverGroup() {
+        return null;
     }
 
     public static class EmptyCommandLatencyCollector implements CommandLatencyCollector {


### PR DESCRIPTION
Closes: #1498 
We now use netty's non-blocking DNS resolver upon connect if optional dependency `netty-dns-resolver` is provided.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

I confirmed netty's non-blocking DNS resolver is actually used by debugger.
(Debug run `AtLeastOnceTest#connectionIsConnectedAfterConnect` with a breakpoint at
https://github.com/netty/netty/blob/netty-4.1.53.Final/transport/src/main/java/io/netty/bootstrap/Bootstrap.java#L206)
![image](https://user-images.githubusercontent.com/7314410/99081497-40938100-2606-11eb-8294-bfc22bc947cd.png)

 <!--
Great! Live long and prosper.
-->

