### PR TITLE
Add RedisSentinelCommands to reflect-config.json #1562

### DIFF
--- a/src/main/resources/META-INF/native-image/io.lettuce/lettuce-core/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/io.lettuce/lettuce-core/reflect-config.json
@@ -145,6 +145,11 @@
     "allDeclaredConstructors": true
   },
   {
+    "name": "io.lettuce.core.sentinel.api.sync.RedisSentinelCommands",
+    "allPublicMethods": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "reactor.core.publisher.Mono"
   }
 ]


### PR DESCRIPTION
Support RedisSentineCommands in GraalVM native image
