### PR TITLE
Add support for ReadFrom.subnet and ReadFrom.regex

### DIFF
--- a/src/main/java/io/lettuce/core/ReadFrom.java
+++ b/src/main/java/io/lettuce/core/ReadFrom.java
@@ -16,6 +16,7 @@
 package io.lettuce.core;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import io.lettuce.core.internal.LettuceStrings;
 import io.lettuce.core.models.role.RedisNodeDescription;
@@ -114,12 +115,24 @@ public abstract class ReadFrom {
     /**
      * Setting to read from any node in the subnets.
      *
-     * @param cidrNotations CIDR-block notation strings, e.g., "192.168.0.0/16".
+     * @param cidrNotations CIDR-block notation strings, e.g., "192.168.0.0/16", "2001:db8:abcd:0000::/52". Must not be
+     *        {@code null}.
      * @return an instance of {@link ReadFromImpl.ReadFromSubnet}.
      * @since x.x.x
      */
     public static ReadFrom subnet(String... cidrNotations) {
         return new ReadFromImpl.ReadFromSubnet(cidrNotations);
+    }
+
+    /**
+     * Read from any node that has {@link RedisURI} matching with the given pattern.
+     *
+     * @param pattern regex pattern, e.g., {@code Pattern.compile(".*region-1.*")}. Must not be {@code null}.
+     * @return an instance of {@link ReadFromImpl.ReadFromRegex}.
+     * @since x.x.x
+     */
+    public static ReadFrom regex(Pattern pattern) {
+        return new ReadFromImpl.ReadFromRegex(pattern);
     }
 
     /**
@@ -192,6 +205,10 @@ public abstract class ReadFrom {
 
         if (name.equalsIgnoreCase("subnet")) {
             throw new IllegalArgumentException("subnet must be created via ReadFrom#subnet");
+        }
+
+        if (name.equalsIgnoreCase("regex")) {
+            throw new IllegalArgumentException("regex must be created via ReadFrom#regex");
         }
 
         throw new IllegalArgumentException("ReadFrom " + name + " not supported");

--- a/src/main/java/io/lettuce/core/ReadFrom.java
+++ b/src/main/java/io/lettuce/core/ReadFrom.java
@@ -26,6 +26,7 @@ import io.lettuce.core.models.role.RedisNodeDescription;
  * @author Mark Paluch
  * @author Ryosuke Hasebe
  * @author Omer Cilingir
+ * @author Yohei Ueki
  * @since 4.0
  */
 public abstract class ReadFrom {
@@ -111,6 +112,17 @@ public abstract class ReadFrom {
     public static final ReadFrom ANY_REPLICA = new ReadFromImpl.ReadFromAnyReplica();
 
     /**
+     * Setting to read from any node in the subnets.
+     *
+     * @param cidrNotations CIDR-block notation strings, e.g., "192.168.0.0/16".
+     * @return an instance of {@link ReadFromImpl.ReadFromSubnet}.
+     * @since x.x.x
+     */
+    public static ReadFrom subnet(String... cidrNotations) {
+        return new ReadFromImpl.ReadFromSubnet(cidrNotations);
+    }
+
+    /**
      * Chooses the nodes from the matching Redis nodes that match this read selector.
      *
      * @param nodes set of nodes that are suitable for reading
@@ -176,6 +188,10 @@ public abstract class ReadFrom {
 
         if (name.equalsIgnoreCase("anyReplica")) {
             return ANY_REPLICA;
+        }
+
+        if (name.equalsIgnoreCase("subnet")) {
+            throw new IllegalArgumentException("subnet must be created via ReadFrom#subnet");
         }
 
         throw new IllegalArgumentException("ReadFrom " + name + " not supported");

--- a/src/test/java/io/lettuce/core/cluster/ReadFromUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ReadFromUnitTests.java
@@ -17,17 +17,18 @@ package io.lettuce.core.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.lettuce.core.ReadFrom;
-import io.lettuce.core.ReadFrom.Nodes;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
@@ -95,7 +96,47 @@ class ReadFromUnitTests {
     }
 
     @Test
-    void subnet() {
+    void subnetIpv4RuleIpv6NodeGiven() {
+        ReadFrom sut = ReadFrom.subnet("0.0.0.0/0");
+        RedisClusterNode ipv6node = createNodeWithHost("2001:db8:abcd:1000::");
+
+        List<RedisNodeDescription> result = sut.select(getNodes(ipv6node));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void subnetIpv4RuleAnyNode() {
+        ReadFrom sut = ReadFrom.subnet("0.0.0.0/0");
+        RedisClusterNode node = createNodeWithHost("192.0.2.1");
+
+        List<RedisNodeDescription> result = sut.select(getNodes(node));
+
+        assertThat(result).hasSize(1).containsExactly(node);
+    }
+
+    @Test
+    void subnetIpv6RuleIpv4NodeGiven() {
+        ReadFrom sut = ReadFrom.subnet("::/0");
+        RedisClusterNode node = createNodeWithHost("192.0.2.1");
+
+        List<RedisNodeDescription> result = sut.select(getNodes(node));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void subnetIpv6RuleAnyNode() {
+        ReadFrom sut = ReadFrom.subnet("::/0");
+        RedisClusterNode node = createNodeWithHost("2001:db8:abcd:1000::");
+
+        List<RedisNodeDescription> result = sut.select(getNodes(node));
+
+        assertThat(result).hasSize(1).containsExactly(node);
+    }
+
+    @Test
+    void subnetIpv4Ipv6Mixed() {
         ReadFrom sut = ReadFrom.subnet("192.0.2.0/24", "2001:db8:abcd:0000::/52");
 
         RedisClusterNode nodeInSubnetIpv4 = createNodeWithHost("192.0.2.1");
@@ -111,30 +152,55 @@ class ReadFromUnitTests {
 
     @Test
     void subnetNodeWithHostname() {
-        ReadFrom sut = ReadFrom.subnet("0.0.0.0/24");
+        ReadFrom sut = ReadFrom.subnet("0.0.0.0/0");
 
-        Nodes hostNode = getNodes(createNodeWithHost("example.com"));
-        assertThatThrownBy(() -> sut.select(hostNode)).isInstanceOf(IllegalArgumentException.class);
+        RedisClusterNode hostNode = createNodeWithHost("example.com");
+        RedisClusterNode localhostNode = createNodeWithHost("localhost");
 
-        Nodes localhostNode = getNodes(createNodeWithHost("localhost"));
-        assertThatThrownBy(() -> sut.select(localhostNode)).isInstanceOf(IllegalArgumentException.class);
+        List<RedisNodeDescription> result = sut.select(getNodes(hostNode, localhostNode));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void subnetCidrValidation() {
+        // malformed CIDR notation
+        assertThatThrownBy(() -> ReadFrom.subnet("192.0.2.1//1")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ReadFrom.subnet("2001:db8:abcd:0000:://52")).isInstanceOf(IllegalArgumentException.class);
+        // malformed ipAddress
+        assertThatThrownBy(() -> ReadFrom.subnet("foo.bar/12")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ReadFrom.subnet("zzzz:db8:abcd:0000:://52")).isInstanceOf(IllegalArgumentException.class);
+        // malformed cidrPrefix
+        assertThatThrownBy(() -> ReadFrom.subnet("192.0.2.1/40")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ReadFrom.subnet("192.0.2.1/foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ReadFrom.subnet("2001:db8:abcd:0000/129")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ReadFrom.subnet("2001:db8:abcd:0000/-1")).isInstanceOf(IllegalArgumentException.class);
+
+        // acceptable cidrPrefix
+        assertDoesNotThrow(() -> ReadFrom.subnet("0.0.0.0/0"));
+        assertDoesNotThrow(() -> ReadFrom.subnet("0.0.0.0/32"));
+        assertDoesNotThrow(() -> ReadFrom.subnet("::/0"));
+        assertDoesNotThrow(() -> ReadFrom.subnet("::/128"));
+    }
+
+    @Test
+    void regex() {
+        ReadFrom sut = ReadFrom.regex(Pattern.compile(".*region-1.*"));
+
+        RedisClusterNode node1 = createNodeWithHost("redis-node-1.region-1.example.com");
+        RedisClusterNode node2 = createNodeWithHost("redis-node-2.region-1.example.com");
+        RedisClusterNode node3 = createNodeWithHost("redis-node-1.region-2.example.com");
+        RedisClusterNode node4 = createNodeWithHost("redis-node-2.region-2.example.com");
+
+        List<RedisNodeDescription> result = sut.select(getNodes(node1, node2, node3, node4));
+
+        assertThat(result).hasSize(2).containsExactly(node1, node2);
     }
 
     private RedisClusterNode createNodeWithHost(String host) {
         RedisClusterNode node = new RedisClusterNode();
         node.setUri(RedisURI.Builder.redis(host).build());
         return node;
-    }
-
-    @Test
-    void subnetInvalidCidr() {
-        // malformed CIDR notation
-        assertThatThrownBy(() -> ReadFrom.subnet("192.0.2.1//1")).isInstanceOf(IllegalArgumentException.class);
-        // malformed ipAddress
-        assertThatThrownBy(() -> ReadFrom.subnet("foo.bar/12")).isInstanceOf(IllegalArgumentException.class);
-        // malformed cidrPrefix
-        assertThatThrownBy(() -> ReadFrom.subnet("192.0.2.1/40")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ReadFrom.subnet("192.0.2.1/foo")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -180,6 +246,11 @@ class ReadFromUnitTests {
     @Test
     void valueOfSubnet() {
         assertThatThrownBy(() -> ReadFrom.valueOf("subnet")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void valueOfRegex() {
+        assertThatThrownBy(() -> ReadFrom.valueOf("regex")).isInstanceOf(IllegalArgumentException.class);
     }
 
     private ReadFrom.Nodes getNodes() {

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterReadFromIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterReadFromIntegrationTests.java
@@ -32,6 +32,7 @@ import io.lettuce.test.LettuceExtension;
 
 /**
  * @author Mark Paluch
+ * @author Yohei Ueki
  */
 @SuppressWarnings("unchecked")
 @ExtendWith(LettuceExtension.class)
@@ -112,4 +113,16 @@ class RedisClusterReadFromIntegrationTests extends TestSupport {
         connection.getConnection(ClusterTestSettings.host, ClusterTestSettings.port2).sync().waitForReplication(1, 1000);
         assertThat(sync.get(key)).isEqualTo("value1");
     }
+
+    @Test
+    void readWriteSubnet() {
+
+        connection.setReadFrom(ReadFrom.subnet("0.0.0.0/0", "::/0"));
+
+        sync.set(key, "value1");
+
+        connection.getConnection(ClusterTestSettings.host, ClusterTestSettings.port2).sync().waitForReplication(1, 1000);
+        assertThat(sync.get(key)).isEqualTo("value1");
+    }
+
 }

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterReadFromIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterReadFromIntegrationTests.java
@@ -17,6 +17,8 @@ package io.lettuce.core.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.regex.Pattern;
+
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.AfterEach;
@@ -118,6 +120,17 @@ class RedisClusterReadFromIntegrationTests extends TestSupport {
     void readWriteSubnet() {
 
         connection.setReadFrom(ReadFrom.subnet("0.0.0.0/0", "::/0"));
+
+        sync.set(key, "value1");
+
+        connection.getConnection(ClusterTestSettings.host, ClusterTestSettings.port2).sync().waitForReplication(1, 1000);
+        assertThat(sync.get(key)).isEqualTo("value1");
+    }
+
+    @Test
+    void readWriteRegex() {
+
+        connection.setReadFrom(ReadFrom.regex(Pattern.compile(".*")));
 
         sync.set(key, "value1");
 


### PR DESCRIPTION
Lettuce now supports ReadFrom.subnet which is an option of reading from any node in the given subnets.

Closes: #1569 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
