### PR TITLE
Fix travis links due to its domain name migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://avatars2.githubusercontent.com/u/25752188?v=4" width="50" height="50"> Lettuce - Advanced Java Redis client
 ===============================
 
-[![Build Status](https://travis-ci.org/lettuce-io/lettuce-core.svg)](https://travis-ci.org/lettuce-io/lettuce-core) [![codecov](https://codecov.io/gh/lettuce-io/lettuce-core/branch/main/graph/badge.svg)](https://codecov.io/gh/lettuce-io/lettuce-core)
+[![Build Status](https://travis-ci.com/lettuce-io/lettuce-core.svg)](https://travis-ci.com/lettuce-io/lettuce-core) [![codecov](https://codecov.io/gh/lettuce-io/lettuce-core/branch/main/graph/badge.svg)](https://codecov.io/gh/lettuce-io/lettuce-core)
  [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lettuce/lettuce-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lettuce/lettuce-core)
 
 Lettuce is a scalable thread-safe Redis client for synchronous,

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <ciManagement>
         <system>Travis CI</system>
-        <url>https://travis-ci.org/lettuce-io/lettuce-core</url>
+        <url>https://travis-ci.com/lettuce-io/lettuce-core</url>
     </ciManagement>
 
     <issueManagement>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21218309/111023864-7564e880-83ec-11eb-9ae1-15c9a20a04ae.png)
