### PR TITLE
prevent crash on non Linux-based OS 

### DIFF
--- a/src/main/java/io/lettuce/core/resource/IOUringProvider.java
+++ b/src/main/java/io/lettuce/core/resource/IOUringProvider.java
@@ -60,9 +60,9 @@ public class IOUringProvider {
         try {
             Class.forName("io.netty.incubator.channel.uring.IOUring");
             availability = IOUring.isAvailable();
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | ExceptionInInitializerError e) {
             availability = false;
-        }
+        } 
 
         IOURING_AVAILABLE = availability;
 


### PR DESCRIPTION
related to https://github.com/lettuce-io/lettuce-core/issues/1786
on the latest version of `netty-incubator-transport-native-io_uring` class `IOUring` may throw an exception during initializing. 
For example on Mac OS Redis connection doesn't work because of this exception https://github.com/netty/netty-incubator-transport-io_uring/blob/main/src/main/java/io/netty/incubator/channel/uring/Native.java#L277
