### PR TITLE
Emit command latency events using JFR

### DIFF
--- a/src/main/java/io/lettuce/core/event/metrics/JfrCommandLatency.java
+++ b/src/main/java/io/lettuce/core/event/metrics/JfrCommandLatency.java
@@ -1,0 +1,46 @@
+package io.lettuce.core.event.metrics;
+
+import io.lettuce.core.metrics.CommandLatencyId;
+import io.lettuce.core.metrics.CommandMetrics;
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.StackTrace;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A JFR event for Each Command Latency
+ * triggered by JfrCommandLatencyEvent
+ *
+ * @see JfrCommandLatency
+ * @author Hash.Jang
+ */
+@Category({ "Lettuce", "Command Events" })
+@Label("Command Latency")
+@StackTrace(false)
+public class JfrCommandLatency extends Event {
+    private final String remoteAddress;
+    private final String commandType;
+    private final long count;
+    private final TimeUnit timeUnit;
+    private final long firstResponseMin;
+    private final long firstResponseMax;
+    private final String firstResponsePercentiles;
+    private final long completionResponseMin;
+    private final long completionResponseMax;
+    private final String completionResponsePercentiles;
+
+    public JfrCommandLatency(CommandLatencyId commandLatencyId, CommandMetrics commandMetrics) {
+        this.remoteAddress = commandLatencyId.remoteAddress().toString();
+        this.commandType = commandLatencyId.commandType().toString();
+        this.count = commandMetrics.getCount();
+        this.timeUnit = commandMetrics.getTimeUnit();
+        this.firstResponseMin = commandMetrics.getFirstResponse().getMin();
+        this.firstResponseMax = commandMetrics.getFirstResponse().getMax();
+        this.firstResponsePercentiles = commandMetrics.getFirstResponse().getPercentiles().toString();
+        this.completionResponseMin = commandMetrics.getCompletion().getMin();
+        this.completionResponseMax = commandMetrics.getCompletion().getMax();
+        this.completionResponsePercentiles = commandMetrics.getCompletion().getPercentiles().toString();
+    }
+}

--- a/src/main/java/io/lettuce/core/event/metrics/JfrCommandLatencyEvent.java
+++ b/src/main/java/io/lettuce/core/event/metrics/JfrCommandLatencyEvent.java
@@ -1,0 +1,28 @@
+package io.lettuce.core.event.metrics;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.StackTrace;
+
+/**
+ * JFR Event for CommandLatencyEvent
+ * A JfrCommandLatencyEvent is only a trigger of multiple JfrCommandLatency
+ *
+ * @see JfrCommandLatency
+ * @author Hash.Jang
+ */
+@Category({ "Lettuce", "Command Events" })
+@Label("Command Latency Trigger")
+@StackTrace(false)
+public class JfrCommandLatencyEvent extends Event {
+    private final int size;
+
+    public JfrCommandLatencyEvent(CommandLatencyEvent commandLatencyEvent) {
+        this.size = commandLatencyEvent.getLatencies().size();
+        commandLatencyEvent.getLatencies().forEach((commandLatencyId, commandMetrics) -> {
+            JfrCommandLatency jfrCommandLatency = new JfrCommandLatency(commandLatencyId, commandMetrics);
+            jfrCommandLatency.commit();
+        });
+    }
+}


### PR DESCRIPTION
Fix: [https://github.com/lettuce-io/lettuce-core/issues/1820](https://github.com/lettuce-io/lettuce-core/issues/1820)

On the basis of current JFR Event generation, add JFR event for CommandLatencyEvent. And support summary report through JMC like the graph below:
![image](https://user-images.githubusercontent.com/15627489/128133081-0d08097c-a51d-449d-acac-288da451fe9d.png)