### PR TITLE
Fixed obvious typo in MicrometerOptions.Builder.minLatency(Duration)

### DIFF
--- a/src/main/java/io/lettuce/core/metrics/MicrometerOptions.java
+++ b/src/main/java/io/lettuce/core/metrics/MicrometerOptions.java
@@ -204,7 +204,7 @@ public class MicrometerOptions {
          * @return this {@link Builder}.
          */
         public Builder minLatency(Duration minLatency) {
-            LettuceAssert.notNull(maxLatency, "Max Latency must not be null");
+            LettuceAssert.notNull(minLatency, "Min Latency must not be null");
             this.minLatency = minLatency;
             return this;
         }


### PR DESCRIPTION
Update MicrometerOptions.java
Fixed obvious typo in MicrometerOptions.Builder.minLatency(Duration) method.