### PR TITLE
Fix `ACL SETUSER` when setting noCommands

### DIFF
--- a/src/main/java/io/lettuce/core/AclSetuserArgs.java
+++ b/src/main/java/io/lettuce/core/AclSetuserArgs.java
@@ -474,7 +474,7 @@ public class AclSetuserArgs implements CompositeArgument {
      * @return {@code this}
      */
     public AclSetuserArgs noCommands() {
-        this.noCommands = false;
+        this.noCommands = true;
         return this;
     }
 

--- a/src/test/java/io/lettuce/core/AclSetuserArgsUnitTests.java
+++ b/src/test/java/io/lettuce/core/AclSetuserArgsUnitTests.java
@@ -36,7 +36,7 @@ class AclSetuserArgsUnitTests {
         CommandArgs<String, String> commandArgs = new CommandArgs<>(StringCodec.UTF8);
         args.build(commandArgs);
 
-        assertThat(commandArgs.toCommandString()).isEqualTo("ON -@ALL");
+        assertThat(commandArgs.toCommandString()).isEqualTo("ON NOCOMMANDS");
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/AclSetuserArgsUnitTests.java
+++ b/src/test/java/io/lettuce/core/AclSetuserArgsUnitTests.java
@@ -30,6 +30,16 @@ import io.lettuce.core.protocol.CommandArgs;
 class AclSetuserArgsUnitTests {
 
     @Test
+    void shouldRemoveAllCommands() {
+
+        AclSetuserArgs args = AclSetuserArgs.Builder.on().noCommands();
+        CommandArgs<String, String> commandArgs = new CommandArgs<>(StringCodec.UTF8);
+        args.build(commandArgs);
+
+        assertThat(commandArgs.toCommandString()).isEqualTo("ON -@ALL");
+    }
+
+    @Test
     void shouldAddCategory() {
 
         AclSetuserArgs args = AclSetuserArgs.Builder.on().addCategory(AclCategory.CONNECTION);


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Hi again @mp911de - I found another bug in `ACL SETUSER` when using the `noCommands()` method - `NOCOMMANDS` was not being added to the command arguments.