### PR TITLE
Gracefully handle calls to DefaultPauseDetectorWrapper#retain during shutdown.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/io/lettuce/core/metrics/DefaultCommandLatencyCollectorUnitTests.java
+++ b/src/test/java/io/lettuce/core/metrics/DefaultCommandLatencyCollectorUnitTests.java
@@ -32,7 +32,6 @@ import io.lettuce.test.ReflectionTestUtils;
 import io.lettuce.core.metrics.DefaultCommandLatencyCollector.PauseDetectorWrapper;
 import io.lettuce.core.protocol.CommandType;
 import io.netty.channel.local.LocalAddress;
-import org.testng.annotations.Ignore;
 
 /**
  * @author Mark Paluch
@@ -142,7 +141,6 @@ class DefaultCommandLatencyCollectorUnitTests {
         sut.shutdown();
     }
 
-    @Ignore
     @Test
     void verifyGracefulShutdownDuringShutdown() {
 


### PR DESCRIPTION
fixes https://github.com/lettuce-io/lettuce-core/issues/1883

 - Gracefully handle calls to DefaultPauseDetectorWrapper#retain during shutdown
 - Use mockito-inline to test static method `Runtime#getRuntime()`
 - Unit test mocked shutdown behavior

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes. **I do not use eclipse. However, I did try to match the surrounding style.**
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
