### PR TITLE
Run flush commands with `FlushMode` on upstreams only

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -35,6 +35,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import io.lettuce.core.AbstractRedisReactiveCommands;
+import io.lettuce.core.FlushMode;
 import io.lettuce.core.GeoArgs;
 import io.lettuce.core.GeoWithin;
 import io.lettuce.core.KeyScanCursor;
@@ -210,6 +211,13 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
     }
 
     @Override
+    public Mono<String> flushall(FlushMode flushMode) {
+
+        Map<String, Publisher<String>> publishers = executeOnUpstream(it -> it.flushall(flushMode));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
     public Mono<String> flushallAsync() {
 
         Map<String, Publisher<String>> publishers = executeOnUpstream(RedisServerReactiveCommands::flushallAsync);
@@ -220,6 +228,13 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
     public Mono<String> flushdb() {
 
         Map<String, Publisher<String>> publishers = executeOnUpstream(RedisServerReactiveCommands::flushdb);
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<String> flushdb(FlushMode flushMode) {
+
+        Map<String, Publisher<String>> publishers = executeOnUpstream(it -> it.flushdb(flushMode));
         return Flux.merge(publishers.values()).last();
     }
 

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+import io.lettuce.core.FlushMode;
 import io.lettuce.core.KeyScanCursor;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisCommandExecutionException;
@@ -234,11 +235,55 @@ class AdvancedClusterReactiveIntegrationTests extends TestSupport {
     }
 
     @Test
+    void flushallSync() {
+
+        writeKeysToTwoNodes();
+
+        StepVerifier.create(commands.flushall(FlushMode.SYNC)).expectNext("OK").verifyComplete();
+
+        Long dbsize = syncCommands.dbsize();
+        assertThat(dbsize).isEqualTo(0);
+    }
+
+    @Test
+    void flushallAsync() {
+
+        writeKeysToTwoNodes();
+
+        StepVerifier.create(commands.flushall(FlushMode.ASYNC)).expectNext("OK").verifyComplete();
+
+        Long dbsize = syncCommands.dbsize();
+        assertThat(dbsize).isEqualTo(0);
+    }
+
+    @Test
     void flushdb() {
 
         writeKeysToTwoNodes();
 
         StepVerifier.create(commands.flushdb()).expectNext("OK").verifyComplete();
+
+        Long dbsize = syncCommands.dbsize();
+        assertThat(dbsize).isEqualTo(0);
+    }
+
+    @Test
+    void flushdbSync() {
+
+        writeKeysToTwoNodes();
+
+        StepVerifier.create(commands.flushdb(FlushMode.SYNC)).expectNext("OK").verifyComplete();
+
+        Long dbsize = syncCommands.dbsize();
+        assertThat(dbsize).isEqualTo(0);
+    }
+
+    @Test
+    void flushdbAsync() {
+
+        writeKeysToTwoNodes();
+
+        StepVerifier.create(commands.flushdb(FlushMode.ASYNC)).expectNext("OK").verifyComplete();
 
         Long dbsize = syncCommands.dbsize();
         assertThat(dbsize).isEqualTo(0);


### PR DESCRIPTION
Ahoy, some of the flush commands are executed on all nodes of a cluster, but should only run on upstreams. This PR adds tests and code changes to address that. I noticed this while working on a solution for https://github.com/spring-projects/spring-data-redis/issues/2187

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
