### PR TITLE
RedisClusterNode: Validate that the RedisURI are equal when comparing nodes

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -21,6 +21,7 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.IntConsumer;
 
@@ -420,6 +421,10 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         RedisClusterNode that = (RedisClusterNode) o;
 
         if (nodeId != null ? !nodeId.equals(that.nodeId) : that.nodeId != null) {
+            return false;
+        }
+
+        if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
             return false;
         }
 

--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -21,7 +21,6 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.IntConsumer;
 

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -57,6 +57,20 @@ class RedisClusterNodeUnitTests {
     }
 
     @Test
+    void testEqualityWithSameNodeIdDifferentHost() {
+
+        RedisClusterNode nodeOne = new RedisClusterNode();
+        nodeOne.setNodeId("123");
+        nodeOne.setUri(RedisURI.builder().withHost("127.0.0.1").build());
+
+        RedisClusterNode nodeTwo = new RedisClusterNode();
+        nodeOne.setNodeId("123");
+        nodeOne.setUri(RedisURI.builder().withHost("127.0.0.2").build());
+
+        assertThat(nodeOne).isNotEqualTo(nodeTwo);
+    }
+
+    @Test
     void testToString() {
 
         RedisClusterNode node = new RedisClusterNode();


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->

For container based instances of Redis, where IP addresses can change, but other data about the node might not (like nodeId) ensure that the URI matches for every node.
Fixes #1909.

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
