### PR TITLE
update to log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <kotlin.version>1.5.30</kotlin.version>
         <kotlinx-coroutines.version>1.5.2</kotlinx-coroutines.version>
         <latencyutils.version>2.0.3</latencyutils.version>
-        <log4j2-version>2.15.0</log4j2-version>
+        <log4j2-version>2.16.0</log4j2-version>
         <micrometer.version>1.7.3</micrometer.version>
         <mockito.version>3.12.4</mockito.version>
         <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
Following https://nvd.nist.gov/vuln/detail/CVE-2021-45046 2.16.0 was released.
More details on 2.16.0 - https://lists.apache.org/thread/d6v4r6nosxysyq9rvnr779336yf0woz4
