### PR TITLE
 Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <kotlin.version>1.5.30</kotlin.version>
         <kotlinx-coroutines.version>1.5.2</kotlinx-coroutines.version>
         <latencyutils.version>2.0.3</latencyutils.version>
-        <log4j2-version>2.15.0</log4j2-version>
+        <log4j2-version>2.17.0</log4j2-version>
         <micrometer.version>1.7.3</micrometer.version>
         <mockito.version>3.12.4</mockito.version>
         <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105