### PR TITLE
Add exception type for `READONLY` errors

### DIFF
--- a/src/main/java/io/lettuce/core/RedisReadOnlyException.java
+++ b/src/main/java/io/lettuce/core/RedisReadOnlyException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lettuce.core;
+
+/**
+ * Exception that gets thrown when Redis replies with a {@code READONLY} error response.
+ *
+ * @author anothertobi
+ */
+@SuppressWarnings("serial")
+public class RedisReadOnlyException extends RedisCommandExecutionException {
+
+    /**
+     * Create a {@code RedisReadOnlyException} with the specified detail message.
+     *
+     * @param msg the detail message.
+     */
+    public RedisReadOnlyException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Create a {@code RedisReadOnlyException} with the specified detail message and nested exception.
+     *
+     * @param msg the detail message.
+     * @param cause the nested exception.
+     */
+    public RedisReadOnlyException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/src/main/java/io/lettuce/core/internal/ExceptionFactory.java
+++ b/src/main/java/io/lettuce/core/internal/ExceptionFactory.java
@@ -134,6 +134,10 @@ public abstract class ExceptionFactory {
                 return cause != null ? new RedisLoadingException(message, cause) : new RedisLoadingException(message);
             }
 
+            if (message.startsWith("READONLY")) {
+                return cause != null ? new RedisReadOnlyException(message, cause) : new RedisReadOnlyException(message);
+            }
+
             return cause != null ? new RedisCommandExecutionException(message, cause)
                     : new RedisCommandExecutionException(message);
         }

--- a/src/test/java/io/lettuce/core/ExceptionFactoryUnitTests.java
+++ b/src/test/java/io/lettuce/core/ExceptionFactoryUnitTests.java
@@ -71,6 +71,16 @@ class ExceptionFactoryUnitTests {
     }
 
     @Test
+    void shouldCreateReadOnlyException() {
+
+        assertThat(ExceptionFactory.createExecutionException("READONLY foo bar")).isInstanceOf(RedisReadOnlyException.class)
+                .hasMessage("READONLY foo bar").hasNoCause();
+        assertThat(ExceptionFactory.createExecutionException("READONLY foo bar", new IllegalStateException()))
+                .isInstanceOf(RedisReadOnlyException.class).hasMessage("READONLY foo bar")
+                .hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
     void shouldFormatExactUnits() {
 
         assertThat(ExceptionFactory.formatTimeout(Duration.ofMinutes(2))).isEqualTo("2 minute(s)");


### PR DESCRIPTION
Redis instances in read-only mode will reply with a `READONLY` error
message when a write is attempted. This change allows users to
specifically handle these errors.

Fixes #1943

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
