### PR TITLE
Separate profile to support m1 chip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,13 +842,28 @@
     <profiles>
 
         <profile>
+            <id>linux-aarch64-fedora</id>
             <activation>
                 <os>
+                    <name>linux</name>
                     <arch>aarch64</arch>
                 </os>
             </activation>
             <properties>
                 <os.detected.classifier>linux-aarch64-fedora</os.detected.classifier>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>apple-silicon</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
             </properties>
         </profile>
 


### PR DESCRIPTION
Create a separate maven profile to support compatibility between apple silicon chip (m1) and netty-tcnative libraries
