### PR TITLE
Reduces overhead of RedisClusterNode.forEachSlot

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -300,7 +300,8 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
             return;
         }
 
-        for (int i = 0; i < this.slots.length(); i++) {
+        int length = this.slots.length();
+        for (int i = 0; i < length; i++) {
 
             if (this.slots.get(i)) {
                 consumer.accept(i);


### PR DESCRIPTION
While investigating this issue (https://github.com/lettuce-io/lettuce-core/issues/2045), I discovered a minor performance issue.

Current `RedisClusterNode.forEachSlot` calls `BitSet.length` every time it loops.
The overhead here seems to be big. Please see the framegraph as follows.

<img width="982" alt="image" src="https://user-images.githubusercontent.com/903482/159021351-5ff40cf1-139f-4164-9b6a-266c2d68e3f0.png">

We can reduce the overhead by calling `BitSet.length` only once.
When measured with JMH, you can see that the throughput(of `RedisClusterNode.forEachSlot`) is improved.

```
Benchmark                                            Mode  Cnt       Score      Error  Units
RedisClusterNodeBenchmark.originalRedisClusterNode  thrpt   25   62364.605 ± 1167.717  ops/s <-- Before
RedisClusterNodeBenchmark.updatedRedisClusterNode   thrpt   25  100597.253 ±  705.268  ops/s <-- After
```

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.