### PR TITLE
Support for re-authentication.

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -116,8 +116,8 @@ public abstract class AbstractRedisClient {
     /**
      * Create a new instance with client resources.
      *
-     * @param clientResources the client resources. If {@code null}, the client will create a new dedicated instance of
-     *        client resources and keep track of them.
+     * @param clientResources the client resources. If {@code null}, the client will create a new dedicated instance of client
+     *        resources and keep track of them.
      */
     protected AbstractRedisClient(ClientResources clientResources) {
 
@@ -269,7 +269,7 @@ public abstract class AbstractRedisClient {
 
     /**
      * Reauthenticate all existing connections.
-     *     
+     * 
      * @since 6.2
      */
     abstract public void reauthConnections();
@@ -423,8 +423,7 @@ public abstract class AbstractRedisClient {
 
         String uriString = connectionBuilder.getRedisURI().toString();
 
-        EventRecorder.getInstance().record(
-                new ConnectionCreatedEvent(uriString, connectionBuilder.endpoint().getId()));
+        EventRecorder.getInstance().record(new ConnectionCreatedEvent(uriString, connectionBuilder.endpoint().getId()));
         EventRecorder.RecordableEvent event = EventRecorder.getInstance()
                 .start(new ConnectEvent(uriString, connectionBuilder.endpoint().getId()));
 
@@ -541,7 +540,7 @@ public abstract class AbstractRedisClient {
     public void shutdown(long quietPeriod, long timeout, TimeUnit timeUnit) {
 
         reauthScheduler.shutdown();
-        
+
         try {
             shutdownAsync(quietPeriod, timeout, timeUnit).get();
         } catch (Exception e) {

--- a/src/main/java/io/lettuce/core/ClientOptions.java
+++ b/src/main/java/io/lettuce/core/ClientOptions.java
@@ -101,7 +101,6 @@ public class ClientOptions implements Serializable {
 
     private final TimeoutOptions timeoutOptions;
 
-
     protected ClientOptions(Builder builder) {
         this.autoReconnect = builder.autoReconnect;
         this.shouldReauthenticatePeriodically = builder.shouldReauthenticatePeriodically;
@@ -172,7 +171,7 @@ public class ClientOptions implements Serializable {
     public static class Builder {
 
         private boolean autoReconnect = DEFAULT_AUTO_RECONNECT;
-        
+
         private boolean shouldReauthenticatePeriodically = DEFAULT_AUTO_REAUTHENTICATE;
 
         private Duration reauthenticationPeriod = DEFAULT_REAUTHENTICATION_PERIOD_DURATION;
@@ -218,9 +217,8 @@ public class ClientOptions implements Serializable {
 
         /**
          * Enables or disables periodic reauthentication of active connections. Defaults to {@code false}. See
-         * {@link #DEFAULT_AUTO_REAUTHENTICATE}.
-         * Defaults period {@literal 60 MINUTES}. See {@link #DEFAULT_REAUTHENTICATE_PERIOD} and
-         * {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
+         * {@link #DEFAULT_AUTO_REAUTHENTICATE}. Defaults period {@literal 60 MINUTES}. See
+         * {@link #DEFAULT_REAUTHENTICATE_PERIOD} and {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
          *
          * @param periodicReauthenticate true/false
          * @return {@code this}
@@ -233,9 +231,8 @@ public class ClientOptions implements Serializable {
 
         /**
          * Enables periodic reauthentication of active connections. Defaults to {@code false}. See
-         * {@link #DEFAULT_AUTO_REAUTHENTICATE}.
-         * Defaults period {@literal 60 MINUTES}. See {@link #DEFAULT_REAUTHENTICATE_PERIOD} and
-         * {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
+         * {@link #DEFAULT_AUTO_REAUTHENTICATE}. Defaults period {@literal 60 MINUTES}. See
+         * {@link #DEFAULT_REAUTHENTICATE_PERIOD} and {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
          *
          * @return {@code this}
          * @since 6.2
@@ -371,8 +368,8 @@ public class ClientOptions implements Serializable {
          * <p>
          * A single Redis connection operates on a single thread. Operations that require a significant amount of processing can
          * lead to a single-threaded-like behavior for all consumers of the Redis connection. When enabled, data signals will be
-         * emitted using a different thread served by {@link ClientResources#eventExecutorGroup()}. Defaults to {@code false}
-         * , see {@link #DEFAULT_PUBLISH_ON_SCHEDULER}.
+         * emitted using a different thread served by {@link ClientResources#eventExecutorGroup()}. Defaults to {@code false} ,
+         * see {@link #DEFAULT_PUBLISH_ON_SCHEDULER}.
          *
          * @param publishOnScheduler true/false
          * @return {@code this}
@@ -399,7 +396,6 @@ public class ClientOptions implements Serializable {
             this.requestQueueSize = requestQueueSize;
             return this;
         }
-
 
         /**
          * Sets the Lua script {@link Charset} to use to encode {@link String scripts} to {@code byte[]}. Defaults to
@@ -492,8 +488,7 @@ public class ClientOptions implements Serializable {
     public ClientOptions.Builder mutate() {
         Builder builder = new Builder();
 
-        builder.autoReconnect(isAutoReconnect())
-                .enablePeriodicReauthentication(isPeriodicReauthenticate())
+        builder.autoReconnect(isAutoReconnect()).enablePeriodicReauthentication(isPeriodicReauthenticate())
                 .reauthenticationPeriod(getReauthenticationPeriod())
                 .cancelCommandsOnReconnectFailure(isCancelCommandsOnReconnectFailure())
                 .decodeBufferPolicy(getDecodeBufferPolicy()).disconnectedBehavior(getDisconnectedBehavior())
@@ -506,9 +501,9 @@ public class ClientOptions implements Serializable {
     }
 
     /**
-     * Controls auto-reconnect behavior on connections. If auto-reconnect is {@code true} (default), it is enabled. As soon
-     * as a connection gets closed/reset without the intention to close it, the client will try to reconnect and re-issue any
-     * queued commands.
+     * Controls auto-reconnect behavior on connections. If auto-reconnect is {@code true} (default), it is enabled. As soon as a
+     * connection gets closed/reset without the intention to close it, the client will try to reconnect and re-issue any queued
+     * commands.
      *
      * This flag has also the effect that disconnected connections will refuse commands and cancel these with an exception.
      *
@@ -519,9 +514,9 @@ public class ClientOptions implements Serializable {
     }
 
     /**
-     * Controls periodic reauthenticate behavior on connections. If periodic reauthenticate is {@code true}, it is enabled. 
-     * In case of rotating password authentication, the client will try to reauth all it's active connections with the 
-     * credentials from the credentials supplier.
+     * Controls periodic reauthenticate behavior on connections. If periodic reauthenticate is {@code true}, it is enabled. In
+     * case of rotating password authentication, the client will try to reauth all it's active connections with the credentials
+     * from the credentials supplier.
      *
      * @return {@code true} if periodic reauthenticate is enabled.
      */
@@ -538,7 +533,6 @@ public class ClientOptions implements Serializable {
     public Duration getReauthenticationPeriod() {
         return reauthenticationPeriod;
     }
-
 
     /**
      * If this flag is {@code true} any queued commands will be canceled when a reconnect fails within the activation sequence.
@@ -637,8 +631,8 @@ public class ClientOptions implements Serializable {
      * <p>
      * A single Redis connection operates on a single thread. Operations that require a significant amount of processing can
      * lead to a single-threaded-like behavior for all consumers of the Redis connection. When enabled, data signals will be
-     * emitted using a different thread served by {@link ClientResources#eventExecutorGroup()}. Defaults to {@code false} ,
-     * see {@link #DEFAULT_PUBLISH_ON_SCHEDULER}.
+     * emitted using a different thread served by {@link ClientResources#eventExecutorGroup()}. Defaults to {@code false} , see
+     * {@link #DEFAULT_PUBLISH_ON_SCHEDULER}.
      *
      * @return {@code true} to use a dedicated {@link reactor.core.scheduler.Scheduler}
      * @since 5.2
@@ -646,7 +640,6 @@ public class ClientOptions implements Serializable {
     public boolean isPublishOnScheduler() {
         return publishOnScheduler;
     }
-
 
     /**
      * If this flag is {@code true} the reconnect will be suspended on protocol errors. Protocol errors are errors while SSL

--- a/src/main/java/io/lettuce/core/ClientOptions.java
+++ b/src/main/java/io/lettuce/core/ClientOptions.java
@@ -18,6 +18,8 @@ package io.lettuce.core;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.internal.LettuceAssert;
@@ -36,6 +38,14 @@ import io.lettuce.core.resource.ClientResources;
 public class ClientOptions implements Serializable {
 
     public static final boolean DEFAULT_AUTO_RECONNECT = true;
+
+    public static final boolean DEFAULT_AUTO_REAUTHENTICATE = false;
+
+    public static final long DEFAULT_REAUTHENTICATE_PERIOD = 60;
+
+    public static final TimeUnit DEFAULT_REAUTHENTICATE_PERIOD_UNIT = TimeUnit.MINUTES;
+
+    public static final Duration DEFAULT_REAUTHENTICATION_PERIOD_DURATION = Duration.ofMinutes(DEFAULT_REAUTHENTICATE_PERIOD);
 
     public static final int DEFAULT_BUFFER_USAGE_RATIO = 3;
 
@@ -62,6 +72,10 @@ public class ClientOptions implements Serializable {
     public static final TimeoutOptions DEFAULT_TIMEOUT_OPTIONS = TimeoutOptions.create();
 
     private final boolean autoReconnect;
+
+    private final boolean shouldReauthenticatePeriodically;
+
+    private final Duration reauthenticationPeriod;
 
     private final boolean cancelCommandsOnReconnectFailure;
 
@@ -90,6 +104,8 @@ public class ClientOptions implements Serializable {
 
     protected ClientOptions(Builder builder) {
         this.autoReconnect = builder.autoReconnect;
+        this.shouldReauthenticatePeriodically = builder.shouldReauthenticatePeriodically;
+        this.reauthenticationPeriod = builder.reauthenticationPeriod;
         this.cancelCommandsOnReconnectFailure = builder.cancelCommandsOnReconnectFailure;
         this.decodeBufferPolicy = builder.decodeBufferPolicy;
         this.disconnectedBehavior = builder.disconnectedBehavior;
@@ -106,6 +122,8 @@ public class ClientOptions implements Serializable {
 
     protected ClientOptions(ClientOptions original) {
         this.autoReconnect = original.isAutoReconnect();
+        this.shouldReauthenticatePeriodically = original.isPeriodicReauthenticate();
+        this.reauthenticationPeriod = original.getReauthenticationPeriod();
         this.cancelCommandsOnReconnectFailure = original.isCancelCommandsOnReconnectFailure();
         this.decodeBufferPolicy = original.getDecodeBufferPolicy();
         this.disconnectedBehavior = original.getDisconnectedBehavior();
@@ -154,6 +172,10 @@ public class ClientOptions implements Serializable {
     public static class Builder {
 
         private boolean autoReconnect = DEFAULT_AUTO_RECONNECT;
+        
+        private boolean shouldReauthenticatePeriodically = DEFAULT_AUTO_REAUTHENTICATE;
+
+        private Duration reauthenticationPeriod = DEFAULT_REAUTHENTICATION_PERIOD_DURATION;
 
         private boolean cancelCommandsOnReconnectFailure = DEFAULT_CANCEL_CMD_RECONNECT_FAIL;
 
@@ -191,6 +213,64 @@ public class ClientOptions implements Serializable {
          */
         public Builder autoReconnect(boolean autoReconnect) {
             this.autoReconnect = autoReconnect;
+            return this;
+        }
+
+        /**
+         * Enables or disables periodic reauthentication of active connections. Defaults to {@code false}. See
+         * {@link #DEFAULT_AUTO_REAUTHENTICATE}.
+         * Defaults period {@literal 60 MINUTES}. See {@link #DEFAULT_REAUTHENTICATE_PERIOD} and
+         * {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
+         *
+         * @param periodicReauthenticate true/false
+         * @return {@code this}
+         * @since 6.2
+         */
+        public Builder enablePeriodicReauthentication(boolean periodicReauthentication) {
+            this.shouldReauthenticatePeriodically = periodicReauthentication;
+            return this;
+        }
+
+        /**
+         * Enables periodic reauthentication of active connections. Defaults to {@code false}. See
+         * {@link #DEFAULT_AUTO_REAUTHENTICATE}.
+         * Defaults period {@literal 60 MINUTES}. See {@link #DEFAULT_REAUTHENTICATE_PERIOD} and
+         * {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
+         *
+         * @return {@code this}
+         * @since 6.2
+         */
+        public Builder enablePeriodicReauthentication() {
+            return enablePeriodicReauthentication(true);
+        }
+
+        /**
+         * Enables periodic reauthentication and sets the reauthentication period. Defaults to {@literal 60 MINUTES}. See
+         * {@link #DEFAULT_REAUTHENTICATE_PERIOD} and {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}. This method is a shortcut for
+         * {@link #reauthenticationPeriod(Duration)} and {@link #enablePeriodicReauthentication()}.
+         *
+         * @param reauthenticationPeriod period for triggering reauthentication, must be greater {@literal 0}
+         * @return {@code this}
+         * @since 6.2
+         */
+        public Builder enablePeriodicReauthentication(Duration reauthenticationPeriod) {
+            return reauthenticationPeriod(reauthenticationPeriod).enablePeriodicReauthentication();
+        }
+
+        /**
+         * Set the reauthentication period. Defaults to {@literal 60 MINUTES}. See {@link #DEFAULT_REAUTHENTICATE_PERIOD} and
+         * {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNIT}.
+         *
+         * @param reauthenticationPeriod period for triggering reauthentication, must be greater {@literal 0}
+         * @return {@code this}
+         * @since 6.2
+         */
+        public Builder reauthenticationPeriod(Duration reauthenticationPeriod) {
+
+            LettuceAssert.notNull(reauthenticationPeriod, "reauthenticationPeriod duration must not be null");
+            LettuceAssert.isTrue(reauthenticationPeriod.toNanos() > 0, "reauthenticationPeriod must be greater 0");
+
+            this.reauthenticationPeriod = reauthenticationPeriod;
             return this;
         }
 
@@ -413,6 +493,8 @@ public class ClientOptions implements Serializable {
         Builder builder = new Builder();
 
         builder.autoReconnect(isAutoReconnect())
+                .enablePeriodicReauthentication(isPeriodicReauthenticate())
+                .reauthenticationPeriod(getReauthenticationPeriod())
                 .cancelCommandsOnReconnectFailure(isCancelCommandsOnReconnectFailure())
                 .decodeBufferPolicy(getDecodeBufferPolicy()).disconnectedBehavior(getDisconnectedBehavior())
                 .publishOnScheduler(isPublishOnScheduler()).pingBeforeActivateConnection(isPingBeforeActivateConnection())
@@ -435,6 +517,28 @@ public class ClientOptions implements Serializable {
     public boolean isAutoReconnect() {
         return autoReconnect;
     }
+
+    /**
+     * Controls periodic reauthenticate behavior on connections. If periodic reauthenticate is {@code true}, it is enabled. 
+     * In case of rotating password authentication, the client will try to reauth all it's active connections with the 
+     * credentials from the credentials supplier.
+     *
+     * @return {@code true} if periodic reauthenticate is enabled.
+     */
+    public boolean isPeriodicReauthenticate() {
+        return shouldReauthenticatePeriodically;
+    }
+
+    /**
+     * Timeout between connections reauthentication. Defaults to {@literal 60 MINUTES}. See
+     * {@link #DEFAULT_REAUTHENTICATE_PERIOD} and {@link #DEFAULT_REAUTHENTICATE_PERIOD_UNI T}.
+     *
+     * @return the period between the connection reauthentication.
+     */
+    public Duration getReauthenticationPeriod() {
+        return reauthenticationPeriod;
+    }
+
 
     /**
      * If this flag is {@code true} any queued commands will be canceled when a reconnect fails within the activation sequence.

--- a/src/main/java/io/lettuce/core/ConnectionState.java
+++ b/src/main/java/io/lettuce/core/ConnectionState.java
@@ -110,6 +110,14 @@ public class ConnectionState {
             return;
         }
 
+        // We cannot safely overwrite credentialsProvider if it isn't StaticCredentialsProvider,
+        // since we don't know what logic it runs, for example whether it dynamically creates the credentials,
+        // or runs some side effect when providing credentials. Since this function might be called periodically automatically, e.g. reauth,
+        // we don't know whether the user intended to overwrite credentialsProvider, so we shouldn't make the decision for them.
+        if (!(this.credentialsProvider instanceof StaticCredentialsProvider)) {
+            return;
+        }
+
         if (args.size() > 1) {
             this.credentialsProvider = new StaticCredentialsProvider(new String(args.get(0)), args.get(1));
         } else {

--- a/src/main/java/io/lettuce/core/ConnectionState.java
+++ b/src/main/java/io/lettuce/core/ConnectionState.java
@@ -112,8 +112,9 @@ public class ConnectionState {
 
         // We cannot safely overwrite credentialsProvider if it isn't StaticCredentialsProvider,
         // since we don't know what logic it runs, for example whether it dynamically creates the credentials,
-        // or runs some side effect when providing credentials. Since this function might be called periodically automatically, e.g. reauth,
-        // we don't know whether the user intended to overwrite credentialsProvider, so we shouldn't make the decision for them.
+        // or runs some side effect when providing credentials. Since this function might be called periodically automatically,
+        // e.g. reauth, we don't know whether the user intended to overwrite credentialsProvider,
+        // so we shouldn't make the decision for them.
         if (!(this.credentialsProvider instanceof StaticCredentialsProvider)) {
             return;
         }

--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -17,6 +17,7 @@ package io.lettuce.core;
 
 import static io.lettuce.core.internal.LettuceStrings.*;
 
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -27,6 +28,8 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
+import java.util.function.Predicate;
+import java.util.function.Consumer;
 
 import reactor.core.publisher.Mono;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -294,7 +297,28 @@ public class RedisClient extends AbstractRedisClient {
             }
         });
 
+        reauthScheduler.activateReauthIfNeeded();
+
         return future;
+    }
+
+    public void reauthConnections() {
+
+        forEachConnection(input -> {
+            input.reauthenticate();
+        });
+
+        forEachPubSubConnection(input -> {
+            input.reauthenticate();
+        });
+    }
+
+    protected void forEachConnection(Consumer<StatefulRedisConnectionImpl<?, ?>> function) {
+        forEachCloseable(input -> input instanceof StatefulRedisConnectionImpl, function);
+    }
+
+    protected void forEachPubSubConnection(Consumer<StatefulRedisPubSubConnectionImpl<?, ?>> function) {
+        forEachCloseable(input -> input instanceof StatefulRedisPubSubConnectionImpl, function);
     }
 
     @SuppressWarnings("unchecked")
@@ -323,6 +347,8 @@ public class RedisClient extends AbstractRedisClient {
         connectionBuilder.connectionInitializer(createHandshake(state));
 
         ConnectionFuture<RedisChannelHandler<K, V>> future = initializeChannelAsync(connectionBuilder);
+
+        reauthScheduler.activateReauthIfNeeded();
 
         return future.thenApply(channelHandler -> (S) connection);
     }
@@ -418,6 +444,8 @@ public class RedisClient extends AbstractRedisClient {
 
         ConnectionFuture<StatefulRedisPubSubConnection<K, V>> future = connectStatefulAsync(connection, endpoint, redisURI,
                 () -> new PubSubCommandHandler<>(getOptions(), getResources(), codec, endpoint));
+
+        reauthScheduler.activateReauthIfNeeded();
 
         return future.whenComplete((conn, throwable) -> {
 

--- a/src/main/java/io/lettuce/core/RedisClientReauthScheduler.java
+++ b/src/main/java/io/lettuce/core/RedisClientReauthScheduler.java
@@ -21,20 +21,21 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 public class RedisClientReauthScheduler implements Runnable {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(RedisClientReauthScheduler.class);
+
     private final AtomicBoolean clientReauthActivated = new AtomicBoolean(false);
+
     private final AtomicReference<ScheduledFuture<?>> clientReauthFuture = new AtomicReference<>();
 
     private final Supplier<ClientOptions> clientOptions;
+
     private final ClientResources clientResources;
+
     private final EventExecutorGroup genericWorkerPool;
 
     private final AbstractRedisClient clientToReauth;
 
-    public RedisClientReauthScheduler(
-        Supplier<ClientOptions> clientOptions,
-        ClientResources clientResources,
-        AbstractRedisClient clientToReauth)
-    {
+    public RedisClientReauthScheduler(Supplier<ClientOptions> clientOptions, ClientResources clientResources,
+            AbstractRedisClient clientToReauth) {
         this.clientOptions = clientOptions;
         this.clientResources = clientResources;
         this.genericWorkerPool = this.clientResources.eventExecutorGroup();
@@ -43,7 +44,7 @@ public class RedisClientReauthScheduler implements Runnable {
 
     public void activateReauthIfNeeded() {
 
-        ClientOptions options = clientOptions.get();        
+        ClientOptions options = clientOptions.get();
 
         if (false == options.isPeriodicReauthenticate()) {
             return;
@@ -51,7 +52,8 @@ public class RedisClientReauthScheduler implements Runnable {
 
         if (clientReauthActivated.compareAndSet(false, true)) {
             ScheduledFuture<?> scheduledFuture = genericWorkerPool.scheduleAtFixedRate(this,
-                options.getReauthenticationPeriod().toNanos(), options.getReauthenticationPeriod().toNanos(), TimeUnit.NANOSECONDS);
+                    options.getReauthenticationPeriod().toNanos(), options.getReauthenticationPeriod().toNanos(),
+                    TimeUnit.NANOSECONDS);
             clientReauthFuture.set(scheduledFuture);
         }
     }
@@ -81,5 +83,6 @@ public class RedisClientReauthScheduler implements Runnable {
         } catch (Exception e) {
             logger.error("Reauthenticate connections failed with: ", e);
         }
-    }    
+    }
+
 }

--- a/src/main/java/io/lettuce/core/RedisClientReauthScheduler.java
+++ b/src/main/java/io/lettuce/core/RedisClientReauthScheduler.java
@@ -1,0 +1,85 @@
+package io.lettuce.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import io.lettuce.core.resource.ClientResources;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.ScheduledFuture;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * Scheduler utility to schedule reauthentication process to all the existing connections.
+ *
+ * @author Barak Gilboa
+ * @since 6.2
+ */
+
+public class RedisClientReauthScheduler implements Runnable {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(RedisClientReauthScheduler.class);
+    private final AtomicBoolean clientReauthActivated = new AtomicBoolean(false);
+    private final AtomicReference<ScheduledFuture<?>> clientReauthFuture = new AtomicReference<>();
+
+    private final Supplier<ClientOptions> clientOptions;
+    private final ClientResources clientResources;
+    private final EventExecutorGroup genericWorkerPool;
+
+    private final AbstractRedisClient clientToReauth;
+
+    public RedisClientReauthScheduler(
+        Supplier<ClientOptions> clientOptions,
+        ClientResources clientResources,
+        AbstractRedisClient clientToReauth)
+    {
+        this.clientOptions = clientOptions;
+        this.clientResources = clientResources;
+        this.genericWorkerPool = this.clientResources.eventExecutorGroup();
+        this.clientToReauth = clientToReauth;
+    }
+
+    public void activateReauthIfNeeded() {
+
+        ClientOptions options = clientOptions.get();        
+
+        if (false == options.isPeriodicReauthenticate()) {
+            return;
+        }
+
+        if (clientReauthActivated.compareAndSet(false, true)) {
+            ScheduledFuture<?> scheduledFuture = genericWorkerPool.scheduleAtFixedRate(this,
+                options.getReauthenticationPeriod().toNanos(), options.getReauthenticationPeriod().toNanos(), TimeUnit.NANOSECONDS);
+            clientReauthFuture.set(scheduledFuture);
+        }
+    }
+
+    /**
+     * Disable periodic reauthentication
+     */
+    public void shutdown() {
+
+        if (clientReauthActivated.compareAndSet(true, false)) {
+
+            ScheduledFuture<?> scheduledFuture = clientReauthFuture.get();
+
+            try {
+                scheduledFuture.cancel(false);
+                clientReauthFuture.set(null);
+            } catch (Exception e) {
+                logger.debug("Could not cancel client reauth", e);
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            clientToReauth.reauthConnections();
+        } catch (Exception e) {
+            logger.error("Reauthenticate connections failed with: ", e);
+        }
+    }    
+}

--- a/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
@@ -295,21 +295,19 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
         return state;
     }
 
-    public void reauthenticate()
-    {
+    public void reauthenticate() {
         RedisCredentialsProvider credentialsProvider = state.getCredentialsProvider();
 
         if (credentialsProvider instanceof RedisCredentialsProvider.ImmediateRedisCredentialsProvider) {
-            RedisCredentials redisCredentials = 
-                ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider)credentialsProvider).resolveCredentialsNow();
+            RedisCredentials redisCredentials = ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider)
+                    .resolveCredentialsNow();
             CharSequence passwd = CharBuffer.wrap(redisCredentials.getPassword());
             if (redisCredentials.hasUsername()) {
                 async().auth(redisCredentials.getUsername(), passwd);
             } else {
                 async().auth(passwd);
             }
-        }
-        else {
+        } else {
             CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentials().toFuture();
             credentialsFuture.thenAcceptAsync(redisCredentials -> {
                 CharSequence passwd = CharBuffer.wrap(redisCredentials.getPassword());
@@ -321,6 +319,6 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
             });
         }
 
-        
     }
+
 }

--- a/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
@@ -24,7 +24,7 @@ import io.lettuce.core.internal.LettuceAssert;
  * @author Mark Paluch
  * @since 6.2
  */
-public class StaticCredentialsProvider
+public final class StaticCredentialsProvider
         implements RedisCredentialsProvider, RedisCredentialsProvider.ImmediateRedisCredentialsProvider {
 
     private final RedisCredentials credentials;

--- a/src/main/java/io/lettuce/core/cluster/ClusterClientOptions.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterClientOptions.java
@@ -124,6 +124,8 @@ public class ClusterClientOptions extends ClientOptions {
 
         Builder builder = new Builder();
         builder.autoReconnect(clientOptions.isAutoReconnect())
+                .enablePeriodicReauthentication(clientOptions.isPeriodicReauthenticate())
+                .reauthenticationPeriod(clientOptions.getReauthenticationPeriod())
                 .cancelCommandsOnReconnectFailure(clientOptions.isCancelCommandsOnReconnectFailure())
                 .decodeBufferPolicy(clientOptions.getDecodeBufferPolicy())
                 .disconnectedBehavior(clientOptions.getDisconnectedBehavior())
@@ -169,6 +171,28 @@ public class ClusterClientOptions extends ClientOptions {
         public Builder autoReconnect(boolean autoReconnect) {
             super.autoReconnect(autoReconnect);
             return this;
+        }
+
+        @Override
+        public Builder enablePeriodicReauthentication(boolean periodicReauthentication) {
+            super.enablePeriodicReauthentication(periodicReauthentication);
+            return this;
+        }
+
+        @Override
+        public Builder enablePeriodicReauthentication() {
+            return enablePeriodicReauthentication(true);
+        }
+
+        @Override
+        public Builder reauthenticationPeriod(Duration reauthenticationPeriod) {
+            super.reauthenticationPeriod(reauthenticationPeriod);
+            return this;
+        }
+
+        @Override
+        public Builder enablePeriodicReauthentication(Duration reauthenticationPeriod) {
+            return reauthenticationPeriod(reauthenticationPeriod).enablePeriodicReauthentication();
         }
 
         /**
@@ -339,6 +363,8 @@ public class ClusterClientOptions extends ClientOptions {
         Builder builder = new Builder();
 
         builder.autoReconnect(isAutoReconnect())
+                .enablePeriodicReauthentication(isPeriodicReauthenticate())
+                .reauthenticationPeriod(getReauthenticationPeriod())
                 .cancelCommandsOnReconnectFailure(isCancelCommandsOnReconnectFailure())
                 .decodeBufferPolicy(getDecodeBufferPolicy())
                 .disconnectedBehavior(getDisconnectedBehavior()).maxRedirects(getMaxRedirects())

--- a/src/main/java/io/lettuce/core/cluster/ClusterClientOptions.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterClientOptions.java
@@ -362,17 +362,15 @@ public class ClusterClientOptions extends ClientOptions {
 
         Builder builder = new Builder();
 
-        builder.autoReconnect(isAutoReconnect())
-                .enablePeriodicReauthentication(isPeriodicReauthenticate())
+        builder.autoReconnect(isAutoReconnect()).enablePeriodicReauthentication(isPeriodicReauthenticate())
                 .reauthenticationPeriod(getReauthenticationPeriod())
                 .cancelCommandsOnReconnectFailure(isCancelCommandsOnReconnectFailure())
-                .decodeBufferPolicy(getDecodeBufferPolicy())
-                .disconnectedBehavior(getDisconnectedBehavior()).maxRedirects(getMaxRedirects())
-                .publishOnScheduler(isPublishOnScheduler()).pingBeforeActivateConnection(isPingBeforeActivateConnection())
-                .protocolVersion(getConfiguredProtocolVersion()).requestQueueSize(getRequestQueueSize())
-                .scriptCharset(getScriptCharset()).socketOptions(getSocketOptions()).sslOptions(getSslOptions())
-                .suspendReconnectOnProtocolFailure(isSuspendReconnectOnProtocolFailure()).timeoutOptions(getTimeoutOptions())
-                .topologyRefreshOptions(getTopologyRefreshOptions())
+                .decodeBufferPolicy(getDecodeBufferPolicy()).disconnectedBehavior(getDisconnectedBehavior())
+                .maxRedirects(getMaxRedirects()).publishOnScheduler(isPublishOnScheduler())
+                .pingBeforeActivateConnection(isPingBeforeActivateConnection()).protocolVersion(getConfiguredProtocolVersion())
+                .requestQueueSize(getRequestQueueSize()).scriptCharset(getScriptCharset()).socketOptions(getSocketOptions())
+                .sslOptions(getSslOptions()).suspendReconnectOnProtocolFailure(isSuspendReconnectOnProtocolFailure())
+                .timeoutOptions(getTimeoutOptions()).topologyRefreshOptions(getTopologyRefreshOptions())
                 .validateClusterNodeMembership(isValidateClusterNodeMembership()).nodeFilter(getNodeFilter());
 
         return builder;
@@ -419,7 +417,6 @@ public class ClusterClientOptions extends ClientOptions {
     public Duration getRefreshPeriod() {
         return topologyRefreshOptions.getRefreshPeriod();
     }
-
 
     /**
      * The {@link ClusterTopologyRefreshOptions} for detailed control of topology updates.

--- a/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
 import io.lettuce.core.ReadFrom;
+import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.cluster.models.partitions.Partitions;
@@ -113,6 +114,13 @@ interface ClusterConnectionProvider extends Closeable {
      * achieve batching. No-op if channel is not connected.
      */
     void flushCommands();
+
+    /**
+     * Reauthenticate all the existing connection
+     * 
+     * @param creds the credentials to authenticate with.
+     */
+    void reauthenticate(RedisCredentials creds);
 
     /**
      * Set from which nodes data is read. The setting is used as default for read operations on this connection. See the

--- a/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
@@ -101,8 +101,8 @@ interface ClusterConnectionProvider extends Closeable {
     void setPartitions(Partitions partitions);
 
     /**
-     * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands
-     * can be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
+     * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
+     * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
      * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.
      *
      * @param autoFlush state of autoFlush.

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -177,8 +177,8 @@ public class RedisClusterClient extends AbstractRedisClient {
      * cluster. If any uri is successful for connection, the others are not tried anymore. The initial uri is needed to discover
      * the cluster structure for distributing the requests.
      *
-     * @param clientResources the client resources. If {@code null}, the client will create a new dedicated instance of
-     *        client resources and keep track of them.
+     * @param clientResources the client resources. If {@code null}, the client will create a new dedicated instance of client
+     *        resources and keep track of them.
      * @param redisURIs iterable of initial {@link RedisURI cluster URIs}. Must not be {@code null} and not empty.
      */
     protected RedisClusterClient(ClientResources clientResources, Iterable<RedisURI> redisURIs) {
@@ -681,7 +681,8 @@ public class RedisClusterClient extends AbstractRedisClient {
                     .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
         }
 
-        return connectionMono.doOnNext(
+        return connectionMono
+                .doOnNext(
                         c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
                 .map(it -> (StatefulRedisClusterConnection<K, V>) it).toFuture();
     }
@@ -947,15 +948,14 @@ public class RedisClusterClient extends AbstractRedisClient {
             input.reauthenticate(creds);
         });
     }
-    
+
     public void reauthConnections() {
         RedisCredentialsProvider credentialsProvider = getFirstUri().getCredentialsProvider();
         if (credentialsProvider instanceof RedisCredentialsProvider.ImmediateRedisCredentialsProvider) {
-            RedisCredentials redisCredentials =
-                ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider)credentialsProvider).resolveCredentialsNow();
+            RedisCredentials redisCredentials = ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider)
+                    .resolveCredentialsNow();
             reauthenticateAllConnections(redisCredentials);
-        }
-        else {
+        } else {
             CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentials().toFuture();
             credentialsFuture.thenAcceptAsync(redisCredentials -> {
                 reauthenticateAllConnections(redisCredentials);

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -19,6 +19,7 @@ import static io.lettuce.core.protocol.CommandType.*;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+import java.nio.CharBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +34,7 @@ import io.lettuce.core.ConnectionState;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisChannelHandler;
 import io.lettuce.core.RedisChannelWriter;
+import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -295,6 +297,19 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
         return partitions;
     }
 
+    public void reauthenticate(RedisCredentials creds)
+    {
+        ClusterConnectionProvider provider = (ClusterConnectionProvider) getClusterDistributionChannelWriter()
+                .getClusterConnectionProvider();
+        CharSequence passwd = CharBuffer.wrap(creds.getPassword());
+        if (creds.hasUsername()) {
+            async().auth(creds.getUsername(), passwd);
+        } else {
+            async().auth(passwd);
+        }
+        provider.reauthenticate(creds);
+    }
+    
     @Override
     public void setReadFrom(ReadFrom readFrom) {
         LettuceAssert.notNull(readFrom, "ReadFrom must not be null");

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
@@ -194,17 +194,16 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
         getClusterDistributionChannelWriter().setPartitions(partitions);
     }
 
-    public void reauthenticate(RedisCredentials creds)
-    {
+    public void reauthenticate(RedisCredentials creds) {
         ClusterConnectionProvider provider = (ClusterConnectionProvider) getClusterDistributionChannelWriter()
                 .getClusterConnectionProvider();
-        CharSequence passwd = CharBuffer.wrap(creds.getPassword());        
+        CharSequence passwd = CharBuffer.wrap(creds.getPassword());
         if (creds.hasUsername()) {
             async().auth(creds.getUsername(), passwd);
         } else {
             async().auth(passwd);
         }
-        provider.reauthenticate(creds);        
+        provider.reauthenticate(creds);
     }
 
     private String getNodeId() {

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
@@ -17,6 +17,7 @@ package io.lettuce.core.cluster;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+import java.nio.CharBuffer;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -24,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisChannelWriter;
+import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
@@ -190,6 +192,19 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
         }
 
         getClusterDistributionChannelWriter().setPartitions(partitions);
+    }
+
+    public void reauthenticate(RedisCredentials creds)
+    {
+        ClusterConnectionProvider provider = (ClusterConnectionProvider) getClusterDistributionChannelWriter()
+                .getClusterConnectionProvider();
+        CharSequence passwd = CharBuffer.wrap(creds.getPassword());        
+        if (creds.hasUsername()) {
+            async().auth(creds.getUsername(), passwd);
+        } else {
+            async().auth(passwd);
+        }
+        provider.reauthenticate(creds);        
     }
 
     private String getNodeId() {

--- a/src/test/java/io/lettuce/core/ClientOptionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/ClientOptionsUnitTests.java
@@ -38,10 +38,8 @@ class ClientOptionsUnitTests {
 
     @Test
     void testBuilder() {
-        ClientOptions options = ClientOptions.builder()
-            .scriptCharset(StandardCharsets.US_ASCII)
-            .enablePeriodicReauthentication(Duration.ofSeconds(10))
-            .build();
+        ClientOptions options = ClientOptions.builder().scriptCharset(StandardCharsets.US_ASCII)
+                .enablePeriodicReauthentication(Duration.ofSeconds(10)).build();
         checkAssertions(options);
         assertThat(options.getScriptCharset()).isEqualTo(StandardCharsets.US_ASCII);
         assertThat(options.getReauthenticationPeriod()).isEqualTo(Duration.ofSeconds(10));
@@ -50,16 +48,14 @@ class ClientOptionsUnitTests {
     @Test
     void testCopy() {
 
-        ClientOptions original = ClientOptions.builder()
-            .scriptCharset(StandardCharsets.US_ASCII)
-            .enablePeriodicReauthentication(Duration.ofSeconds(10))
-            .build();
+        ClientOptions original = ClientOptions.builder().scriptCharset(StandardCharsets.US_ASCII)
+                .enablePeriodicReauthentication(Duration.ofSeconds(10)).build();
         ClientOptions copy = ClientOptions.copyOf(original);
 
         checkAssertions(copy);
         assertThat(copy.getScriptCharset()).isEqualTo(StandardCharsets.US_ASCII);
         assertThat(copy.mutate().build().getScriptCharset()).isEqualTo(StandardCharsets.US_ASCII);
-        
+
         assertThat(copy.getReauthenticationPeriod()).isEqualTo(Duration.ofSeconds(10));
         assertThat(copy.mutate().build().getReauthenticationPeriod()).isEqualTo(Duration.ofSeconds(10));
 
@@ -73,4 +69,5 @@ class ClientOptionsUnitTests {
         assertThat(sut.isSuspendReconnectOnProtocolFailure()).isFalse();
         assertThat(sut.getDisconnectedBehavior()).isEqualTo(ClientOptions.DisconnectedBehavior.DEFAULT);
     }
+
 }

--- a/src/test/java/io/lettuce/core/ClientOptionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/ClientOptionsUnitTests.java
@@ -18,6 +18,7 @@ package io.lettuce.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,20 +38,30 @@ class ClientOptionsUnitTests {
 
     @Test
     void testBuilder() {
-        ClientOptions options = ClientOptions.builder().scriptCharset(StandardCharsets.US_ASCII).build();
+        ClientOptions options = ClientOptions.builder()
+            .scriptCharset(StandardCharsets.US_ASCII)
+            .enablePeriodicReauthentication(Duration.ofSeconds(10))
+            .build();
         checkAssertions(options);
         assertThat(options.getScriptCharset()).isEqualTo(StandardCharsets.US_ASCII);
+        assertThat(options.getReauthenticationPeriod()).isEqualTo(Duration.ofSeconds(10));
     }
 
     @Test
     void testCopy() {
 
-        ClientOptions original = ClientOptions.builder().scriptCharset(StandardCharsets.US_ASCII).build();
+        ClientOptions original = ClientOptions.builder()
+            .scriptCharset(StandardCharsets.US_ASCII)
+            .enablePeriodicReauthentication(Duration.ofSeconds(10))
+            .build();
         ClientOptions copy = ClientOptions.copyOf(original);
 
         checkAssertions(copy);
         assertThat(copy.getScriptCharset()).isEqualTo(StandardCharsets.US_ASCII);
         assertThat(copy.mutate().build().getScriptCharset()).isEqualTo(StandardCharsets.US_ASCII);
+        
+        assertThat(copy.getReauthenticationPeriod()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(copy.mutate().build().getReauthenticationPeriod()).isEqualTo(Duration.ofSeconds(10));
 
         assertThat(original.mutate()).isNotSameAs(copy.mutate());
     }

--- a/src/test/java/io/lettuce/core/cluster/ClusterClientOptionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterClientOptionsUnitTests.java
@@ -105,4 +105,5 @@ class ClusterClientOptionsUnitTests {
         assertThat(copy.getScriptCharset()).isEqualTo(options.getScriptCharset());
         assertThat(options.mutate()).isNotSameAs(copy.mutate());
     }
+
 }

--- a/src/test/java/io/lettuce/core/cluster/ClusterClientOptionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterClientOptionsUnitTests.java
@@ -18,6 +18,7 @@ package io.lettuce.core.cluster;
 import static org.assertj.core.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,8 @@ class ClusterClientOptionsUnitTests {
     void testCopy() {
 
         Predicate<RedisClusterNode> nodeFilter = it -> true;
-        ClusterClientOptions options = ClusterClientOptions.builder().autoReconnect(false).requestQueueSize(100)
+        ClusterClientOptions options = ClusterClientOptions.builder().autoReconnect(false)
+                .enablePeriodicReauthentication(Duration.ofSeconds(13)).requestQueueSize(100)
                 .suspendReconnectOnProtocolFailure(true).maxRedirects(1234).validateClusterNodeMembership(false)
                 .protocolVersion(ProtocolVersion.RESP2).nodeFilter(nodeFilter).build();
 
@@ -50,6 +52,8 @@ class ClusterClientOptionsUnitTests {
         assertThat(copy.isValidateClusterNodeMembership()).isEqualTo(options.isValidateClusterNodeMembership());
         assertThat(copy.getRequestQueueSize()).isEqualTo(options.getRequestQueueSize());
         assertThat(copy.isAutoReconnect()).isEqualTo(options.isAutoReconnect());
+        assertThat(copy.isPeriodicReauthenticate()).isEqualTo(options.isPeriodicReauthenticate());
+        assertThat(copy.getReauthenticationPeriod()).isEqualTo(options.getReauthenticationPeriod());
         assertThat(copy.isCancelCommandsOnReconnectFailure()).isEqualTo(options.isCancelCommandsOnReconnectFailure());
         assertThat(copy.isSuspendReconnectOnProtocolFailure()).isEqualTo(options.isSuspendReconnectOnProtocolFailure());
         assertThat(copy.getMaxRedirects()).isEqualTo(options.getMaxRedirects());
@@ -69,6 +73,7 @@ class ClusterClientOptionsUnitTests {
         assertThat(clusterClientOptions.getTimeoutOptions()).isEqualTo(clusterClientOptions.getTimeoutOptions());
         assertThat(clusterClientOptions.getRequestQueueSize()).isEqualTo(clusterClientOptions.getRequestQueueSize());
         assertThat(clusterClientOptions.isAutoReconnect()).isEqualTo(clusterClientOptions.isAutoReconnect());
+        assertThat(clusterClientOptions.isPeriodicReauthenticate()).isEqualTo(clusterClientOptions.isPeriodicReauthenticate());
         assertThat(clusterClientOptions.isCloseStaleConnections()).isEqualTo(clusterClientOptions.isCloseStaleConnections());
         assertThat(clusterClientOptions.isCancelCommandsOnReconnectFailure())
                 .isEqualTo(clusterClientOptions.isCancelCommandsOnReconnectFailure());
@@ -93,6 +98,7 @@ class ClusterClientOptionsUnitTests {
         assertThat(copy.isValidateClusterNodeMembership()).isEqualTo(options.isValidateClusterNodeMembership());
         assertThat(copy.getRequestQueueSize()).isEqualTo(options.getRequestQueueSize());
         assertThat(copy.isAutoReconnect()).isEqualTo(options.isAutoReconnect());
+        assertThat(copy.isPeriodicReauthenticate()).isEqualTo(options.isPeriodicReauthenticate());
         assertThat(copy.isCancelCommandsOnReconnectFailure()).isEqualTo(options.isCancelCommandsOnReconnectFailure());
         assertThat(copy.isSuspendReconnectOnProtocolFailure()).isEqualTo(options.isSuspendReconnectOnProtocolFailure());
         assertThat(copy.getMaxRedirects()).isEqualTo(options.getMaxRedirects());


### PR DESCRIPTION
Support for re-authentication.

This change allows the client to support automatic recurring reauthentication. This, in combination with the credentials provider allows the user to setup a server with ephemeral passwords, that requires periodic re-authentication with new credentials, in order to maintain a secure connection. An example of such an authentication scheme is AWS' [IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html)

A scheduler was added to the clients (Redis/Cluster) that runs reauth on configurable time.
The scheduler runs a callback in the clients to go over all the existing connections and send AUTH query on it.

In simple client, it runs AUTH over the connections, taking the credentials from the connection's connectionState.
It takes the credentials from each of the connection in order to support MasterReplica client as well.

In cluster client, it runs AUTH command on the existing connections in the connection provider and also on the default connection of the client. It takes the credentials from the client's FirstUri to AUTH all the existing connections.

This feature is disabled by default.
The default period between reauthentication attempts is 60 minutes.
