### PR TITLE
Implements autoclosable interface in abstractredisclient

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -79,7 +79,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @since 3.0
  * @see ClientResources
  */
-public abstract class AbstractRedisClient {
+public abstract class AbstractRedisClient implements AutoCloseable {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractRedisClient.class);
 
@@ -482,6 +482,11 @@ public abstract class AbstractRedisClient {
      */
     public void shutdown() {
         shutdown(0, 2, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void close() {
+        shutdown();
     }
 
     /**


### PR DESCRIPTION
Makes AbstractRedisClient implement AutoClosable so that it can be used in [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) statement 