### PR TITLE
Added getConnection() methods that take a ConnectionIntent to Cluster…

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/AsyncClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/AsyncClusterConnectionProvider.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CompletableFuture;
 
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 
 /**
  * Asynchronous connection provider for cluster operations.
@@ -31,41 +30,41 @@ import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 interface AsyncClusterConnectionProvider extends Closeable {
 
     /**
-     * Provide a connection for the intent and cluster slot. The underlying connection is bound to the nodeId. If the slot
+     * Provide a connection for the connectionIntent and cluster slot. The underlying connection is bound to the nodeId. If the slot
      * responsibility changes, the connection will not point to the updated nodeId.
      *
-     * @param intent {@link Intent#READ} or {@link Intent#WRITE}. {@literal READ} connections will be provided with
+     * @param connectionIntent {@link ConnectionIntent#READ} or {@link ConnectionIntent#WRITE}. {@literal READ} connections will be provided with
      *        {@literal READONLY} mode set.
      * @param slot the slot-hash of the key, see {@link SlotHash}.
      * @return a valid connection which handles the slot.
      * @throws RedisException if no know node can be found for the slot
      */
-    <K, V> CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(Intent intent, int slot);
+    <K, V> CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(ConnectionIntent connectionIntent, int slot);
 
     /**
-     * Provide a connection for the intent and host/port. The connection can survive cluster topology updates. The connection
+     * Provide a connection for the connectionIntent and host/port. The connection can survive cluster topology updates. The connection
      * will be closed if the node identified by {@code host} and {@code port} is no longer part of the cluster.
      *
-     * @param intent {@link Intent#READ} or {@link Intent#WRITE}. {@literal READ} connections will be provided with
+     * @param connectionIntent {@link ConnectionIntent#READ} or {@link ConnectionIntent#WRITE}. {@literal READ} connections will be provided with
      *        {@literal READONLY} mode set.
      * @param host host of the node.
      * @param port port of the node.
      * @return a valid connection to the given host.
      * @throws RedisException if the host is not part of the cluster
      */
-    <K, V> CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(Intent intent, String host, int port);
+    <K, V> CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(ConnectionIntent connectionIntent, String host, int port);
 
     /**
-     * Provide a connection for the intent and nodeId. The connection can survive cluster topology updates. The connection will
+     * Provide a connection for the connectionIntent and nodeId. The connection can survive cluster topology updates. The connection will
      * be closed if the node identified by {@code nodeId} is no longer part of the cluster.
      *
-     * @param intent {@link Intent#READ} or {@link Intent#WRITE}. {@literal READ} connections will be provided with
+     * @param connectionIntent {@link ConnectionIntent#READ} or {@link ConnectionIntent#WRITE}. {@literal READ} connections will be provided with
      *        {@literal READONLY} mode set.
      * @param nodeId the nodeId of the cluster node.
      * @return a valid connection to the given nodeId.
      * @throws RedisException if the {@code nodeId} is not part of the cluster
      */
-    <K, V> CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(Intent intent, String nodeId);
+    <K, V> CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(ConnectionIntent connectionIntent, String nodeId);
 
     /**
      * Close the connections and free all resources.

--- a/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
@@ -32,41 +32,41 @@ import io.lettuce.core.cluster.models.partitions.Partitions;
 interface ClusterConnectionProvider extends Closeable {
 
     /**
-     * Provide a connection for the intent and cluster slot. The underlying connection is bound to the nodeId. If the slot
+     * Provide a connection for the connectionIntent and cluster slot. The underlying connection is bound to the nodeId. If the slot
      * responsibility changes, the connection will not point to the updated nodeId.
      *
-     * @param intent {@link Intent#READ} or {@link ClusterConnectionProvider.Intent#WRITE}. {@literal READ} connections will be
+     * @param connectionIntent {@link ConnectionIntent#READ} or {@link ConnectionIntent#WRITE}. {@literal READ} connections will be
      *        provided with {@literal READONLY} mode set.
      * @param slot the slot-hash of the key, see {@link SlotHash}.
      * @return a valid connection which handles the slot.
      * @throws RedisException if no know node can be found for the slot
      */
-    <K, V> StatefulRedisConnection<K, V> getConnection(Intent intent, int slot);
+    <K, V> StatefulRedisConnection<K, V> getConnection(ConnectionIntent connectionIntent, int slot);
 
     /**
-     * Provide a connection for the intent and host/port. The connection can survive cluster topology updates. The connection
+     * Provide a connection for the connectionIntent and host/port. The connection can survive cluster topology updates. The connection
      * will be closed if the node identified by {@code host} and {@code port} is no longer part of the cluster.
      *
-     * @param intent {@link Intent#READ} or {@link Intent#WRITE}. {@literal READ} connections will be provided with
+     * @param connectionIntent {@link ConnectionIntent#READ} or {@link ConnectionIntent#WRITE}. {@literal READ} connections will be provided with
      *        {@literal READONLY} mode set.
      * @param host host of the node.
      * @param port port of the node.
      * @return a valid connection to the given host.
      * @throws RedisException if the host is not part of the cluster
      */
-    <K, V> StatefulRedisConnection<K, V> getConnection(Intent intent, String host, int port);
+    <K, V> StatefulRedisConnection<K, V> getConnection(ConnectionIntent connectionIntent, String host, int port);
 
     /**
-     * Provide a connection for the intent and nodeId. The connection can survive cluster topology updates. The connection will
+     * Provide a connection for the connectionIntent and nodeId. The connection can survive cluster topology updates. The connection will
      * be closed if the node identified by {@code nodeId} is no longer part of the cluster.
      *
-     * @param intent {@link Intent#READ} or {@link Intent#WRITE}. {@literal READ} connections will be provided with
+     * @param connectionIntent {@link ConnectionIntent#READ} or {@link ConnectionIntent#WRITE}. {@literal READ} connections will be provided with
      *        {@literal READONLY} mode set.
      * @param nodeId the nodeId of the cluster node.
      * @return a valid connection to the given nodeId.
      * @throws RedisException if the {@code nodeId} is not part of the cluster
      */
-    <K, V> StatefulRedisConnection<K, V> getConnection(Intent intent, String nodeId);
+    <K, V> StatefulRedisConnection<K, V> getConnection(ConnectionIntent connectionIntent, String nodeId);
 
     /**
      * Close the connections and free all resources.
@@ -128,9 +128,5 @@ interface ClusterConnectionProvider extends Closeable {
      * @return the read from setting
      */
     ReadFrom getReadFrom();
-
-    enum Intent {
-        READ, WRITE;
-    }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/ClusterDistributionChannelWriter.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterDistributionChannelWriter.java
@@ -34,7 +34,6 @@ import io.lettuce.core.RedisChannelHandler;
 import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 import io.lettuce.core.cluster.event.AskRedirectionEvent;
 import io.lettuce.core.cluster.event.MovedRedirectionEvent;
 import io.lettuce.core.cluster.models.partitions.Partitions;
@@ -142,7 +141,7 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
                 command.getOutput().setError((String) null);
 
                 CompletableFuture<StatefulRedisConnection<K, V>> connectFuture = asyncClusterConnectionProvider
-                        .getConnectionAsync(Intent.WRITE, target.getHostText(), target.getPort());
+                        .getConnectionAsync(ConnectionIntent.WRITE, target.getHostText(), target.getPort());
 
                 if (isSuccessfullyCompleted(connectFuture)) {
                     writeCommand(command, asking, connectFuture.join(), null);
@@ -164,10 +163,10 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
             if (encodedKey != null) {
 
                 int hash = getSlot(encodedKey);
-                Intent intent = getIntent(command.getType());
+                ConnectionIntent connectionIntent = getIntent(command.getType());
 
                 CompletableFuture<StatefulRedisConnection<K, V>> connectFuture = ((AsyncClusterConnectionProvider) clusterConnectionProvider)
-                        .getConnectionAsync(intent, hash);
+                        .getConnectionAsync(connectionIntent, hash);
 
                 if (isSuccessfullyCompleted(connectFuture)) {
                     writeCommand(commandToSend, false, connectFuture.join(), null);
@@ -278,7 +277,7 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
 
         // TODO: Retain order or retain Intent preference?
         // Currently: Retain order
-        Intent intent = getIntent(commands);
+        ConnectionIntent connectionIntent = getIntent(commands);
 
         for (RedisCommand<K, V, ?> cmd : commands) {
 
@@ -297,7 +296,7 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
 
             int hash = getSlot(args.getFirstEncodedKey());
 
-            List<ClusterCommand<K, V, ?>> commandPartition = partitions.computeIfAbsent(SlotIntent.of(intent, hash),
+            List<ClusterCommand<K, V, ?>> commandPartition = partitions.computeIfAbsent(SlotIntent.of(connectionIntent, hash),
                     slotIntent -> new ArrayList<>());
 
             commandPartition.add(new ClusterCommand<>(cmd, this, executionLimit));
@@ -307,7 +306,7 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
 
             SlotIntent slotIntent = entry.getKey();
             RedisChannelHandler<K, V> connection = (RedisChannelHandler<K, V>) clusterConnectionProvider
-                    .getConnection(slotIntent.intent, slotIntent.slotHash);
+                    .getConnection(slotIntent.connectionIntent, slotIntent.slotHash);
 
             RedisChannelWriter channelWriter = connection.getChannelWriter();
             if (channelWriter instanceof ClusterDistributionChannelWriter) {
@@ -329,17 +328,17 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
     /**
      * Optimization: Determine command intents and optimize for bulk execution preferring one node.
      * <p>
-     * If there is only one intent, then we take the intent derived from the commands. If there is more than one intent, then
-     * use {@link Intent#WRITE}.
+     * If there is only one connectionIntent, then we take the connectionIntent derived from the commands. If there is more than one connectionIntent, then
+     * use {@link ConnectionIntent#WRITE}.
      *
      * @param commands {@link Collection} of {@link RedisCommand commands}.
-     * @return the intent.
+     * @return the connectionIntent.
      */
-    static Intent getIntent(Collection<? extends RedisCommand<?, ?, ?>> commands) {
+    static ConnectionIntent getIntent(Collection<? extends RedisCommand<?, ?, ?>> commands) {
 
         boolean w = false;
         boolean r = false;
-        Intent singleIntent = Intent.WRITE;
+        ConnectionIntent singleConnectionIntent = ConnectionIntent.WRITE;
 
         for (RedisCommand<?, ?, ?> command : commands) {
 
@@ -347,25 +346,25 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
                 continue;
             }
 
-            singleIntent = getIntent(command.getType());
-            if (singleIntent == Intent.READ) {
+            singleConnectionIntent = getIntent(command.getType());
+            if (singleConnectionIntent == ConnectionIntent.READ) {
                 r = true;
             }
 
-            if (singleIntent == Intent.WRITE) {
+            if (singleConnectionIntent == ConnectionIntent.WRITE) {
                 w = true;
             }
 
             if (r && w) {
-                return Intent.WRITE;
+                return ConnectionIntent.WRITE;
             }
         }
 
-        return singleIntent;
+        return singleConnectionIntent;
     }
 
-    private static Intent getIntent(ProtocolKeyword type) {
-        return ReadOnlyCommands.isReadOnlyCommand(type) ? Intent.READ : Intent.WRITE;
+    private static ConnectionIntent getIntent(ProtocolKeyword type) {
+        return ReadOnlyCommands.isReadOnlyCommand(type) ? ConnectionIntent.READ : ConnectionIntent.WRITE;
     }
 
     static HostAndPort getMoveTarget(String errorMessage) {
@@ -523,7 +522,7 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
 
         final int slotHash;
 
-        final Intent intent;
+        final ConnectionIntent connectionIntent;
 
         private static final SlotIntent[] READ;
 
@@ -535,20 +534,20 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
 
             IntStream.range(0, SlotHash.SLOT_COUNT).forEach(i -> {
 
-                READ[i] = new SlotIntent(i, Intent.READ);
-                WRITE[i] = new SlotIntent(i, Intent.WRITE);
+                READ[i] = new SlotIntent(i, ConnectionIntent.READ);
+                WRITE[i] = new SlotIntent(i, ConnectionIntent.WRITE);
             });
 
         }
 
-        private SlotIntent(int slotHash, Intent intent) {
+        private SlotIntent(int slotHash, ConnectionIntent connectionIntent) {
             this.slotHash = slotHash;
-            this.intent = intent;
+            this.connectionIntent = connectionIntent;
         }
 
-        public static SlotIntent of(Intent intent, int slot) {
+        public static SlotIntent of(ConnectionIntent connectionIntent, int slot) {
 
-            if (intent == Intent.READ) {
+            if (connectionIntent == ConnectionIntent.READ) {
                 return READ[slot];
             }
 
@@ -566,13 +565,13 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
 
             if (slotHash != that.slotHash)
                 return false;
-            return intent == that.intent;
+            return connectionIntent == that.connectionIntent;
         }
 
         @Override
         public int hashCode() {
             int result = slotHash;
-            result = 31 * result + intent.hashCode();
+            result = 31 * result + connectionIntent.hashCode();
             return result;
         }
 

--- a/src/main/java/io/lettuce/core/cluster/ClusterFutureSyncInvocationHandler.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterFutureSyncInvocationHandler.java
@@ -98,15 +98,15 @@ class ClusterFutureSyncInvocationHandler<K, V> extends AbstractInvocationHandler
             }
 
             if (method.getName().equals("readonly") && args.length == 1) {
-                return nodes((Predicate<RedisClusterNode>) args[0], ClusterConnectionProvider.Intent.READ, false);
+                return nodes((Predicate<RedisClusterNode>) args[0], ConnectionIntent.READ, false);
             }
 
             if (method.getName().equals("nodes") && args.length == 1) {
-                return nodes((Predicate<RedisClusterNode>) args[0], ClusterConnectionProvider.Intent.WRITE, false);
+                return nodes((Predicate<RedisClusterNode>) args[0], ConnectionIntent.WRITE, false);
             }
 
             if (method.getName().equals("nodes") && args.length == 2) {
-                return nodes((Predicate<RedisClusterNode>) args[0], ClusterConnectionProvider.Intent.WRITE, (Boolean) args[1]);
+                return nodes((Predicate<RedisClusterNode>) args[0], ConnectionIntent.WRITE, (Boolean) args[1]);
             }
 
             Method targetMethod = apiMethodCache.computeIfAbsent(method, key -> {
@@ -172,7 +172,7 @@ class ClusterFutureSyncInvocationHandler<K, V> extends AbstractInvocationHandler
         }
     }
 
-    protected Object nodes(Predicate<RedisClusterNode> predicate, ClusterConnectionProvider.Intent intent, boolean dynamic) {
+    protected Object nodes(Predicate<RedisClusterNode> predicate, ConnectionIntent connectionIntent, boolean dynamic) {
 
         NodeSelectionSupport<RedisCommands<K, V>, ?> selection = null;
 
@@ -182,11 +182,11 @@ class ClusterFutureSyncInvocationHandler<K, V> extends AbstractInvocationHandler
 
             if (dynamic) {
                 selection = new DynamicNodeSelection<RedisCommands<K, V>, Object, K, V>(
-                        impl.getClusterDistributionChannelWriter(), predicate, intent, StatefulRedisConnection::sync);
+                        impl.getClusterDistributionChannelWriter(), predicate, connectionIntent, StatefulRedisConnection::sync);
             } else {
 
                 selection = new StaticNodeSelection<RedisCommands<K, V>, Object, K, V>(
-                        impl.getClusterDistributionChannelWriter(), predicate, intent, StatefulRedisConnection::sync);
+                        impl.getClusterDistributionChannelWriter(), predicate, connectionIntent, StatefulRedisConnection::sync);
             }
         }
 
@@ -194,7 +194,7 @@ class ClusterFutureSyncInvocationHandler<K, V> extends AbstractInvocationHandler
 
             StatefulRedisClusterPubSubConnectionImpl<K, V> impl = (StatefulRedisClusterPubSubConnectionImpl<K, V>) connection;
             selection = new StaticNodeSelection<RedisCommands<K, V>, Object, K, V>(impl.getClusterDistributionChannelWriter(),
-                    predicate, intent, StatefulRedisConnection::sync);
+                    predicate, connectionIntent, StatefulRedisConnection::sync);
         }
 
         NodeSelectionInvocationHandler h = new NodeSelectionInvocationHandler((AbstractNodeSelection<?, ?, ?, ?>) selection,

--- a/src/main/java/io/lettuce/core/cluster/ClusterNodeConnectionFactory.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterNodeConnectionFactory.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import io.lettuce.core.ConnectionFuture;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 
 /**
@@ -45,7 +44,7 @@ interface ClusterNodeConnectionFactory<K, V>
      */
     class ConnectionKey {
 
-        final Intent intent;
+        final ConnectionIntent connectionIntent;
 
         final String nodeId;
 
@@ -53,15 +52,15 @@ interface ClusterNodeConnectionFactory<K, V>
 
         final int port;
 
-        public ConnectionKey(Intent intent, String nodeId) {
-            this.intent = intent;
+        public ConnectionKey(ConnectionIntent connectionIntent, String nodeId) {
+            this.connectionIntent = connectionIntent;
             this.nodeId = nodeId;
             this.host = null;
             this.port = 0;
         }
 
-        public ConnectionKey(Intent intent, String host, int port) {
-            this.intent = intent;
+        public ConnectionKey(ConnectionIntent connectionIntent, String host, int port) {
+            this.connectionIntent = connectionIntent;
             this.host = host;
             this.port = port;
             this.nodeId = null;
@@ -79,7 +78,7 @@ interface ClusterNodeConnectionFactory<K, V>
 
             if (port != key.port)
                 return false;
-            if (intent != key.intent)
+            if (connectionIntent != key.connectionIntent)
                 return false;
             if (nodeId != null ? !nodeId.equals(key.nodeId) : key.nodeId != null)
                 return false;
@@ -89,7 +88,7 @@ interface ClusterNodeConnectionFactory<K, V>
         @Override
         public int hashCode() {
 
-            int result = intent != null ? intent.name().hashCode() : 0;
+            int result = connectionIntent != null ? connectionIntent.name().hashCode() : 0;
             result = 31 * result + (nodeId != null ? nodeId.hashCode() : 0);
             result = 31 * result + (host != null ? host.hashCode() : 0);
             result = 31 * result + port;
@@ -101,7 +100,7 @@ interface ClusterNodeConnectionFactory<K, V>
 
             StringBuffer sb = new StringBuffer();
             sb.append(getClass().getSimpleName());
-            sb.append(" [intent=").append(intent);
+            sb.append(" [connectionIntent=").append(connectionIntent);
             sb.append(", nodeId='").append(nodeId).append('\'');
             sb.append(", host='").append(host).append('\'');
             sb.append(", port=").append(port);

--- a/src/main/java/io/lettuce/core/cluster/ConnectionIntent.java
+++ b/src/main/java/io/lettuce/core/cluster/ConnectionIntent.java
@@ -1,0 +1,5 @@
+package io.lettuce.core.cluster;
+
+public enum ConnectionIntent {
+    READ, WRITE;
+}

--- a/src/main/java/io/lettuce/core/cluster/DynamicNodeSelection.java
+++ b/src/main/java/io/lettuce/core/cluster/DynamicNodeSelection.java
@@ -40,15 +40,15 @@ class DynamicNodeSelection<API, CMD, K, V> extends AbstractNodeSelection<API, CM
 
     private final Predicate<RedisClusterNode> selector;
 
-    private final ClusterConnectionProvider.Intent intent;
+    private final ConnectionIntent connectionIntent;
 
     private final Function<StatefulRedisConnection<K, V>, API> apiExtractor;
 
     public DynamicNodeSelection(ClusterDistributionChannelWriter writer, Predicate<RedisClusterNode> selector,
-            ClusterConnectionProvider.Intent intent, Function<StatefulRedisConnection<K, V>, API> apiExtractor) {
+                                ConnectionIntent connectionIntent, Function<StatefulRedisConnection<K, V>, API> apiExtractor) {
 
         this.selector = selector;
-        this.intent = intent;
+        this.connectionIntent = connectionIntent;
         this.writer = writer;
         this.apiExtractor = apiExtractor;
     }
@@ -59,7 +59,7 @@ class DynamicNodeSelection<API, CMD, K, V> extends AbstractNodeSelection<API, CM
         RedisURI uri = redisClusterNode.getUri();
         AsyncClusterConnectionProvider async = (AsyncClusterConnectionProvider) writer.getClusterConnectionProvider();
 
-        return async.getConnectionAsync(intent, uri.getHost(), uri.getPort());
+        return async.getConnectionAsync(connectionIntent, uri.getHost(), uri.getPort());
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
@@ -514,12 +514,12 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
     }
 
     private CompletableFuture<RedisClusterAsyncCommands<K, V>> getConnectionAsync(String nodeId) {
-        return getConnectionProvider().<K, V> getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, nodeId)
+        return getConnectionProvider().<K, V> getConnectionAsync(ConnectionIntent.WRITE, nodeId)
                 .thenApply(StatefulRedisConnection::async);
     }
 
     private CompletableFuture<RedisClusterAsyncCommands<K, V>> getConnectionAsync(String host, int port) {
-        return getConnectionProvider().<K, V> getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, host, port)
+        return getConnectionProvider().<K, V> getConnectionAsync(ConnectionIntent.WRITE, host, port)
                 .thenApply(StatefulRedisConnection::async);
     }
 
@@ -535,16 +535,16 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
 
     @Override
     public AsyncNodeSelection<K, V> readonly(Predicate<RedisClusterNode> predicate) {
-        return nodes(predicate, ClusterConnectionProvider.Intent.READ, false);
+        return nodes(predicate, ConnectionIntent.READ, false);
     }
 
     @Override
     public AsyncNodeSelection<K, V> nodes(Predicate<RedisClusterNode> predicate, boolean dynamic) {
-        return nodes(predicate, ClusterConnectionProvider.Intent.WRITE, dynamic);
+        return nodes(predicate, ConnectionIntent.WRITE, dynamic);
     }
 
     @SuppressWarnings("unchecked")
-    protected AsyncNodeSelection<K, V> nodes(Predicate<RedisClusterNode> predicate, ClusterConnectionProvider.Intent intent,
+    protected AsyncNodeSelection<K, V> nodes(Predicate<RedisClusterNode> predicate, ConnectionIntent connectionIntent,
             boolean dynamic) {
 
         NodeSelectionSupport<RedisAsyncCommands<K, V>, ?> selection;
@@ -552,10 +552,10 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
         StatefulRedisClusterConnectionImpl<K, V> impl = (StatefulRedisClusterConnectionImpl<K, V>) getConnection();
         if (dynamic) {
             selection = new DynamicNodeSelection<RedisAsyncCommands<K, V>, Object, K, V>(
-                    impl.getClusterDistributionChannelWriter(), predicate, intent, StatefulRedisConnection::async);
+                    impl.getClusterDistributionChannelWriter(), predicate, connectionIntent, StatefulRedisConnection::async);
         } else {
             selection = new StaticNodeSelection<RedisAsyncCommands<K, V>, Object, K, V>(
-                    impl.getClusterDistributionChannelWriter(), predicate, intent, StatefulRedisConnection::async);
+                    impl.getClusterDistributionChannelWriter(), predicate, connectionIntent, StatefulRedisConnection::async);
         }
 
         NodeSelectionInvocationHandler h = new NodeSelectionInvocationHandler((AbstractNodeSelection<?, ?, ?, ?>) selection,

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -39,7 +39,6 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
 import io.lettuce.core.api.reactive.RedisScriptingReactiveCommands;
 import io.lettuce.core.api.reactive.RedisServerReactiveCommands;
-import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
@@ -440,7 +439,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
     }
 
     private Mono<RedisClusterReactiveCommands<K, V>> getConnectionReactive(String nodeId) {
-        return getMono(getConnectionProvider().<K, V> getConnectionAsync(Intent.WRITE, nodeId))
+        return getMono(getConnectionProvider().<K, V> getConnectionAsync(ConnectionIntent.WRITE, nodeId))
                 .map(StatefulRedisConnection::reactive);
     }
 
@@ -450,7 +449,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
     }
 
     private Mono<RedisClusterReactiveCommands<K, V>> getConnectionReactive(String host, int port) {
-        return getMono(getConnectionProvider().<K, V> getConnectionAsync(Intent.WRITE, host, port))
+        return getMono(getConnectionProvider().<K, V> getConnectionAsync(ConnectionIntent.WRITE, host, port))
                 .map(StatefulRedisConnection::reactive);
     }
 
@@ -600,7 +599,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
         String currentNodeId = ClusterScanSupport.getCurrentNodeId(cursor, nodeIds);
         ScanCursor continuationCursor = ClusterScanSupport.getContinuationCursor(cursor);
 
-        Mono<T> scanCursor = getMono(connectionProvider.<K, V> getConnectionAsync(Intent.WRITE, currentNodeId))
+        Mono<T> scanCursor = getMono(connectionProvider.<K, V> getConnectionAsync(ConnectionIntent.WRITE, currentNodeId))
                 .flatMap(conn -> scanFunction.apply(conn.reactive(), continuationCursor));
         return mapper.map(nodeIds, currentNodeId, scanCursor);
     }

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubAsyncCommandsImpl.java
@@ -130,7 +130,7 @@ public class RedisClusterPubSubAsyncCommandsImpl<K, V> extends RedisPubSubAsyncC
             RedisURI uri = redisClusterNode.getUri();
             AsyncClusterConnectionProvider async = (AsyncClusterConnectionProvider) writer.getClusterConnectionProvider();
 
-            return async.getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, uri.getHost(), uri.getPort())
+            return async.getConnectionAsync(ConnectionIntent.WRITE, uri.getHost(), uri.getPort())
                     .thenApply(it -> (StatefulRedisPubSubConnection<K, V>) it);
         }
 

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubReactiveCommandsImpl.java
@@ -129,7 +129,7 @@ public class RedisClusterPubSubReactiveCommandsImpl<K, V> extends RedisPubSubRea
 
             AsyncClusterConnectionProvider async = (AsyncClusterConnectionProvider) writer.getClusterConnectionProvider();
 
-            return async.getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, uri.getHost(), uri.getPort())
+            return async.getConnectionAsync(ConnectionIntent.WRITE, uri.getHost(), uri.getPort())
                     .thenApply(it -> (StatefulRedisPubSubConnection<K, V>) it);
         }
 

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -157,6 +157,11 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
 
     @Override
     public StatefulRedisConnection<K, V> getConnection(String nodeId) {
+        return getConnection(nodeId, ConnectionIntent.WRITE);
+    }
+
+    @Override
+    public StatefulRedisConnection<K, V> getConnection(String nodeId, ConnectionIntent connectionIntent) {
 
         RedisURI redisURI = lookup(nodeId);
 
@@ -165,11 +170,36 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
         }
 
         return getClusterDistributionChannelWriter().getClusterConnectionProvider()
-                .getConnection(ClusterConnectionProvider.Intent.WRITE, nodeId);
+                .getConnection(connectionIntent, nodeId);
     }
 
     @Override
     public CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(String nodeId) {
+        return getConnectionAsync(nodeId, ConnectionIntent.WRITE);
+    }
+
+    /**
+     * Retrieve asynchronously a connection to the specified cluster node using the nodeId. Host and port are looked up in the
+     * node list. This connection is bound to the node id. Once the cluster topology view is updated, the connection will try to
+     * reconnect the to the node with the specified {@code nodeId}, that behavior can also lead to a closed connection once the
+     * node with the specified {@code nodeId} is no longer part of the cluster.
+     * <p>
+     * Do not close the connections. Otherwise, unpredictable behavior will occur. The nodeId must be part of the cluster and is
+     * validated against the current topology view in {@link Partitions}.
+     * <p>
+     * This method is intended to be used for cases where the caller requires a specific connection type (READ or WRITE) to a
+     * given node in a cluster.
+     * <p>
+     * In contrast to the {@link StatefulRedisClusterConnection}, node-connections do not route commands to other cluster nodes.
+     *
+     * @param nodeId           the node Id
+     * @param connectionIntent the intent for usage of the connection.
+     * @return {@link CompletableFuture} to indicate success or failure to connect to the requested cluster node.
+     * @throws RedisException if the requested node identified by {@code nodeId} is not part of the cluster
+     * @since 5.0
+     */
+    @Override
+    public CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(String nodeId, ConnectionIntent connectionIntent) {
 
         RedisURI redisURI = lookup(nodeId);
 
@@ -180,23 +210,50 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
         AsyncClusterConnectionProvider provider = (AsyncClusterConnectionProvider) getClusterDistributionChannelWriter()
                 .getClusterConnectionProvider();
 
-        return provider.getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, nodeId);
+        return provider.getConnectionAsync(connectionIntent, nodeId);
     }
 
     @Override
     public StatefulRedisConnection<K, V> getConnection(String host, int port) {
+        return getConnection(host, port, ConnectionIntent.WRITE);
+    }
+
+    @Override
+    public StatefulRedisConnection<K, V> getConnection(String host, int port, ConnectionIntent connectionIntent) {
 
         return getClusterDistributionChannelWriter().getClusterConnectionProvider()
-                .getConnection(ClusterConnectionProvider.Intent.WRITE, host, port);
+                .getConnection(connectionIntent, host, port);
     }
 
     @Override
     public CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(String host, int port) {
+        return getConnectionAsync(host, port, ConnectionIntent.WRITE);
+    }
+
+    /**
+     * Retrieve asynchronously a connection to the specified cluster node using host and port. This connection is bound to a
+     * host and port. Updates to the cluster topology view can close the connection once the host, identified by {@code host}
+     * and {@code port}, are no longer part of the cluster.
+     * <p>
+     * Do not close the connections. Otherwise, unpredictable behavior will occur. Host and port connections are verified by
+     * default for cluster membership, see {@link ClusterClientOptions#isValidateClusterNodeMembership()}.
+     * <p>
+     * In contrast to the {@link StatefulRedisClusterConnection}, node-connections do not route commands to other cluster nodes.
+     *
+     * @param host             the host
+     * @param port             the port
+     * @param connectionIntent the intent of the connection see {@link #getConnection(String, ConnectionIntent)}
+     * @return {@link CompletableFuture} to indicate success or failure to connect to the requested cluster node.
+     * @throws RedisException if the requested node identified by {@code host} and {@code port} is not part of the cluster
+     * @since 5.0
+     */
+    @Override
+    public CompletableFuture<StatefulRedisConnection<K, V>> getConnectionAsync(String host, int port, ConnectionIntent connectionIntent) {
 
         AsyncClusterConnectionProvider provider = (AsyncClusterConnectionProvider) getClusterDistributionChannelWriter()
                 .getClusterConnectionProvider();
 
-        return provider.getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, host, port);
+        return provider.getConnectionAsync(connectionIntent, host, port);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
@@ -133,7 +133,7 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
         }
 
         return (StatefulRedisPubSubConnection<K, V>) getClusterDistributionChannelWriter().getClusterConnectionProvider()
-                .getConnection(ClusterConnectionProvider.Intent.WRITE, nodeId);
+                .getConnection(ConnectionIntent.WRITE, nodeId);
     }
 
     @Override
@@ -148,7 +148,7 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
 
         AsyncClusterConnectionProvider provider = (AsyncClusterConnectionProvider) getClusterDistributionChannelWriter()
                 .getClusterConnectionProvider();
-        return (CompletableFuture) provider.getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, nodeId);
+        return (CompletableFuture) provider.getConnectionAsync(ConnectionIntent.WRITE, nodeId);
 
     }
 
@@ -156,7 +156,7 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
     public StatefulRedisPubSubConnection<K, V> getConnection(String host, int port) {
 
         return (StatefulRedisPubSubConnection<K, V>) getClusterDistributionChannelWriter().getClusterConnectionProvider()
-                .getConnection(ClusterConnectionProvider.Intent.WRITE, host, port);
+                .getConnection(ConnectionIntent.WRITE, host, port);
     }
 
     @Override
@@ -165,7 +165,7 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
         AsyncClusterConnectionProvider provider = (AsyncClusterConnectionProvider) getClusterDistributionChannelWriter()
                 .getClusterConnectionProvider();
 
-        return (CompletableFuture) provider.getConnectionAsync(ClusterConnectionProvider.Intent.WRITE, host, port);
+        return (CompletableFuture) provider.getConnectionAsync(ConnectionIntent.WRITE, host, port);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/StaticNodeSelection.java
+++ b/src/main/java/io/lettuce/core/cluster/StaticNodeSelection.java
@@ -38,17 +38,17 @@ class StaticNodeSelection<API, CMD, K, V> extends AbstractNodeSelection<API, CMD
 
     private final ClusterDistributionChannelWriter writer;
 
-    private final ClusterConnectionProvider.Intent intent;
+    private final ConnectionIntent connectionIntent;
 
     private final List<RedisClusterNode> redisClusterNodes;
 
     private final Function<StatefulRedisConnection<K, V>, API> apiExtractor;
 
     public StaticNodeSelection(ClusterDistributionChannelWriter writer, Predicate<RedisClusterNode> selector,
-            ClusterConnectionProvider.Intent intent, Function<StatefulRedisConnection<K, V>, API> apiExtractor) {
+                               ConnectionIntent connectionIntent, Function<StatefulRedisConnection<K, V>, API> apiExtractor) {
 
         this.writer = writer;
-        this.intent = intent;
+        this.connectionIntent = connectionIntent;
         this.apiExtractor = apiExtractor;
 
         this.redisClusterNodes = writer.getPartitions().stream().filter(selector).collect(Collectors.toList());
@@ -60,7 +60,7 @@ class StaticNodeSelection<API, CMD, K, V> extends AbstractNodeSelection<API, CMD
         RedisURI uri = redisClusterNode.getUri();
 
         AsyncClusterConnectionProvider async = (AsyncClusterConnectionProvider) writer.getClusterConnectionProvider();
-        return async.getConnectionAsync(intent, uri.getHost(), uri.getPort());
+        return async.getConnectionAsync(connectionIntent, uri.getHost(), uri.getPort());
     }
 
     @Override

--- a/src/test/java/io/lettuce/core/cluster/AsyncConnectionProviderIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AsyncConnectionProviderIntegrationTests.java
@@ -99,7 +99,7 @@ class AsyncConnectionProviderIntegrationTests {
     @Test
     void shouldCloseConnectionByKey() throws IOException {
 
-        ConnectionKey connectionKey = new ConnectionKey(ClusterConnectionProvider.Intent.READ, TestSettings.host(),
+        ConnectionKey connectionKey = new ConnectionKey(ConnectionIntent.READ, TestSettings.host(),
                 TestSettings.port());
 
         sut.getConnection(connectionKey);
@@ -114,7 +114,7 @@ class AsyncConnectionProviderIntegrationTests {
     @Test
     void shouldCloseConnections() throws IOException {
 
-        ConnectionKey connectionKey = new ConnectionKey(ClusterConnectionProvider.Intent.READ, TestSettings.host(),
+        ConnectionKey connectionKey = new ConnectionKey(ConnectionIntent.READ, TestSettings.host(),
                 TestSettings.port());
 
         sut.getConnection(connectionKey);
@@ -136,7 +136,7 @@ class AsyncConnectionProviderIntegrationTests {
 
         client.setOptions(clientOptions);
 
-        ConnectionKey connectionKey = new ConnectionKey(ClusterConnectionProvider.Intent.READ, "8.8.8.8", TestSettings.port());
+        ConnectionKey connectionKey = new ConnectionKey(ConnectionIntent.READ, "8.8.8.8", TestSettings.port());
 
         StopWatch stopWatch = new StopWatch();
 
@@ -169,7 +169,7 @@ class AsyncConnectionProviderIntegrationTests {
 
         client.setOptions(clientOptions);
 
-        ConnectionKey connectionKey = new ConnectionKey(ClusterConnectionProvider.Intent.READ, "8.8.8.8", TestSettings.port());
+        ConnectionKey connectionKey = new ConnectionKey(ConnectionIntent.READ, "8.8.8.8", TestSettings.port());
 
         Thread t1 = new Thread(() -> {
             try {

--- a/src/test/java/io/lettuce/core/cluster/ClusterDistributionChannelWriterUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterDistributionChannelWriterUnitTests.java
@@ -38,7 +38,6 @@ import io.lettuce.core.CommandListenerWriter;
 import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.event.EventBus;
 import io.lettuce.core.internal.HostAndPort;
@@ -137,15 +136,15 @@ class ClusterDistributionChannelWriterUnitTests {
         RedisCommand<String, String, String> set = new Command<>(CommandType.SET, null);
         RedisCommand<String, String, String> mset = new Command<>(CommandType.MSET, null);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(set, mset))).isEqualTo(Intent.WRITE);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(set, mset))).isEqualTo(ConnectionIntent.WRITE);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(set))).isEqualTo(Intent.WRITE);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(set))).isEqualTo(ConnectionIntent.WRITE);
     }
 
     @Test
     void shouldReturnDefaultIntentForNoCommands() {
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.emptyList())).isEqualTo(Intent.WRITE);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.emptyList())).isEqualTo(ConnectionIntent.WRITE);
     }
 
     @Test
@@ -154,9 +153,9 @@ class ClusterDistributionChannelWriterUnitTests {
         RedisCommand<String, String, String> get = new Command<>(CommandType.GET, null);
         RedisCommand<String, String, String> mget = new Command<>(CommandType.MGET, null);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(get, mget))).isEqualTo(Intent.READ);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(get, mget))).isEqualTo(ConnectionIntent.READ);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(get))).isEqualTo(Intent.READ);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(get))).isEqualTo(ConnectionIntent.READ);
     }
 
     @Test
@@ -165,9 +164,9 @@ class ClusterDistributionChannelWriterUnitTests {
         RedisCommand<String, String, String> set = new Command<>(CommandType.SET, null);
         RedisCommand<String, String, String> mget = new Command<>(CommandType.MGET, null);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(set, mget))).isEqualTo(Intent.WRITE);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(set, mget))).isEqualTo(ConnectionIntent.WRITE);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(set))).isEqualTo(Intent.WRITE);
+        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(set))).isEqualTo(ConnectionIntent.WRITE);
     }
 
     @Test
@@ -210,7 +209,7 @@ class ClusterDistributionChannelWriterUnitTests {
         when(connectFuture.isDone()).thenReturn(true);
         when(connectFuture.isCompletedExceptionally()).thenReturn(false);
         when(connectFuture.join()).thenReturn(connection);
-        when(pooledClusterConnectionProvider.getConnectionAsync(any(Intent.class), anyString(), anyInt()))
+        when(pooledClusterConnectionProvider.getConnectionAsync(any(ConnectionIntent.class), anyString(), anyInt()))
                 .thenReturn(connectFuture);
         when(connection.getChannelWriter()).thenReturn(clusterNodeEndpoint);
 

--- a/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
@@ -46,7 +46,6 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
 import io.lettuce.core.api.sync.RedisCommands;
-import io.lettuce.core.cluster.ClusterConnectionProvider.Intent;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.StringCodec;
@@ -122,7 +121,7 @@ class PooledClusterConnectionProviderUnitTests {
                 .thenReturn(
                 ConnectionFuture.from(socketAddressMock, CompletableFuture.completedFuture(nodeConnectionMock)));
 
-        StatefulRedisConnection<String, String> connection = sut.getConnection(Intent.READ, 1);
+        StatefulRedisConnection<String, String> connection = sut.getConnection(ConnectionIntent.READ, 1);
 
         assertThat(connection).isSameAs(nodeConnectionMock);
         verify(connection).setAutoFlushCommands(true);
@@ -139,7 +138,7 @@ class PooledClusterConnectionProviderUnitTests {
 
         sut.setReadFrom(ReadFrom.UPSTREAM);
 
-        StatefulRedisConnection<String, String> connection = sut.getConnection(Intent.READ, 1);
+        StatefulRedisConnection<String, String> connection = sut.getConnection(ConnectionIntent.READ, 1);
 
         assertThat(connection).isSameAs(nodeConnectionMock);
         verify(connection).setAutoFlushCommands(true);
@@ -160,7 +159,7 @@ class PooledClusterConnectionProviderUnitTests {
 
         sut.setReadFrom(ReadFrom.REPLICA);
 
-        StatefulRedisConnection<String, String> connection = sut.getConnection(Intent.READ, 1);
+        StatefulRedisConnection<String, String> connection = sut.getConnection(ConnectionIntent.READ, 1);
 
         assertThat(connection).isSameAs(nodeConnectionMock);
         verify(connection).async();
@@ -182,7 +181,7 @@ class PooledClusterConnectionProviderUnitTests {
 
         sut.setReadFrom(ReadFrom.REPLICA);
 
-        assertThatExceptionOfType(PartitionSelectorException.class).isThrownBy(() -> sut.getConnection(Intent.READ, 1));
+        assertThatExceptionOfType(PartitionSelectorException.class).isThrownBy(() -> sut.getConnection(ConnectionIntent.READ, 1));
     }
 
     @Test
@@ -209,7 +208,7 @@ class PooledClusterConnectionProviderUnitTests {
         List<StatefulRedisConnection<String, String>> readCandidates = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
-            readCandidates.add(sut.getConnection(Intent.READ, 1));
+            readCandidates.add(sut.getConnection(ConnectionIntent.READ, 1));
         }
 
         assertThat(readCandidates).contains(nodeConnectionMock, nodeConnectionMock2);
@@ -239,7 +238,7 @@ class PooledClusterConnectionProviderUnitTests {
         List<StatefulRedisConnection<String, String>> readCandidates = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
-            readCandidates.add(sut.getConnection(Intent.READ, 1));
+            readCandidates.add(sut.getConnection(ConnectionIntent.READ, 1));
         }
 
         assertThat(readCandidates).contains(nodeConnectionMock2).doesNotContain(nodeConnectionMock);
@@ -259,7 +258,7 @@ class PooledClusterConnectionProviderUnitTests {
         sut.setReadFrom(ReadFrom.REPLICA);
 
         try {
-            sut.getConnection(Intent.READ, 1);
+            sut.getConnection(ConnectionIntent.READ, 1);
             fail("Missing RedisException");
         } catch (RedisException e) {
             assertThat(e).hasRootCauseInstanceOf(RuntimeException.class);
@@ -283,7 +282,7 @@ class PooledClusterConnectionProviderUnitTests {
         sut.setReadFrom(ReadFrom.REPLICA);
 
         try {
-            sut.getConnection(Intent.READ, 1);
+            sut.getConnection(ConnectionIntent.READ, 1);
             fail("Missing RedisException");
         } catch (RedisException e) {
             assertThat(e).hasRootCauseInstanceOf(RuntimeException.class);
@@ -295,7 +294,7 @@ class PooledClusterConnectionProviderUnitTests {
 
         when(asyncCommandsMock.readOnly()).thenReturn(async);
 
-        sut.getConnection(Intent.READ, 1);
+        sut.getConnection(ConnectionIntent.READ, 1);
 
         verify(clientMock, times(2)).connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:2"), any(), any());
     }
@@ -319,10 +318,10 @@ class PooledClusterConnectionProviderUnitTests {
 
         sut.setReadFrom(ReadFrom.UPSTREAM_PREFERRED);
 
-        assertThat(sut.getConnection(Intent.READ, 1)).isNotNull().isSameAs(nodeConnectionMock);
+        assertThat(sut.getConnection(ConnectionIntent.READ, 1)).isNotNull().isSameAs(nodeConnectionMock);
 
         // cache access
-        assertThat(sut.getConnection(Intent.READ, 1)).isNotNull().isSameAs(nodeConnectionMock);
+        assertThat(sut.getConnection(ConnectionIntent.READ, 1)).isNotNull().isSameAs(nodeConnectionMock);
 
         verify(clientMock).connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any());
         verify(clientMock).connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:2"), any(), any());
@@ -349,7 +348,7 @@ class PooledClusterConnectionProviderUnitTests {
         sut.setReadFrom(ReadFrom.UPSTREAM_PREFERRED);
 
         try {
-            sut.getConnection(Intent.READ, 1);
+            sut.getConnection(ConnectionIntent.READ, 1);
             fail("Missing RedisException");
         } catch (RedisException e) {
             assertThat(e).isInstanceOf(RedisConnectionException.class)
@@ -365,7 +364,7 @@ class PooledClusterConnectionProviderUnitTests {
 
         partitions.clear();
 
-        sut.getConnectionAsync(Intent.WRITE, 2);
+        sut.getConnectionAsync(ConnectionIntent.WRITE, 2);
 
         verify(clusterEventListener).onUncoveredSlot(2);
     }
@@ -375,7 +374,7 @@ class PooledClusterConnectionProviderUnitTests {
 
         partitions.clear();
 
-        sut.getConnectionAsync(Intent.WRITE, 2);
+        sut.getConnectionAsync(ConnectionIntent.WRITE, 2);
 
         verify(clusterEventListener).onUncoveredSlot(2);
     }
@@ -390,7 +389,7 @@ class PooledClusterConnectionProviderUnitTests {
             }
         });
 
-        sut.getConnectionAsync(Intent.READ, 2);
+        sut.getConnectionAsync(ConnectionIntent.READ, 2);
 
         verify(clusterEventListener).onUncoveredSlot(2);
     }
@@ -403,7 +402,7 @@ class PooledClusterConnectionProviderUnitTests {
         when(clientMock.connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any()))
                 .thenReturn(ConnectionFuture.from(socketAddressMock, CompletableFuture.completedFuture(nodeConnectionMock)));
 
-        StatefulRedisConnection<String, String> connection = sut.getConnection(Intent.READ, 1);
+        StatefulRedisConnection<String, String> connection = sut.getConnection(ConnectionIntent.READ, 1);
         assertThat(connection).isNotNull();
 
         sut.close();
@@ -414,7 +413,7 @@ class PooledClusterConnectionProviderUnitTests {
     @Test
     void shouldRejectConnectionsToUnknownNodeId() {
 
-        assertThatThrownBy(() -> sut.getConnection(Intent.READ, "foobar")).isInstanceOf(UnknownPartitionException.class);
+        assertThatThrownBy(() -> sut.getConnection(ConnectionIntent.READ, "foobar")).isInstanceOf(UnknownPartitionException.class);
 
         verify(clusterEventListener).onUnknownNode();
     }
@@ -422,7 +421,7 @@ class PooledClusterConnectionProviderUnitTests {
     @Test
     void shouldRejectConnectionsToUnknownNodeHostAndPort() {
 
-        assertThatThrownBy(() -> sut.getConnection(Intent.READ, "localhost", 1234))
+        assertThatThrownBy(() -> sut.getConnection(ConnectionIntent.READ, "localhost", 1234))
                 .isInstanceOf(UnknownPartitionException.class);
 
         verify(clusterEventListener).onUnknownNode();

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterStressScenariosTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterStressScenariosTest.java
@@ -133,7 +133,7 @@ public class RedisClusterStressScenariosTest extends TestSupport {
         ClusterDistributionChannelWriter writer = (ClusterDistributionChannelWriter) statefulConnection.getChannelWriter();
 
         StatefulRedisConnectionImpl<Object, Object> statefulSlotConnection = (StatefulRedisConnectionImpl) writer
-                .getClusterConnectionProvider().getConnection(ClusterConnectionProvider.Intent.WRITE, 3300);
+                .getClusterConnectionProvider().getConnection(ConnectionIntent.WRITE, 3300);
 
         final RedisAsyncCommands<Object, Object> slotConnection = statefulSlotConnection.async();
 

--- a/src/test/jmh/io/lettuce/core/cluster/ClusterDistributionChannelWriterBenchmark.java
+++ b/src/test/jmh/io/lettuce/core/cluster/ClusterDistributionChannelWriterBenchmark.java
@@ -86,7 +86,7 @@ public class ClusterDistributionChannelWriterBenchmark {
         writer.setPartitions(partitions);
         writer.setClusterConnectionProvider(new PooledClusterConnectionProvider(new EmptyRedisClusterClient(RedisURI.create(
                 "localhost", 7379)), EMPTY_WRITER, ByteArrayCodec.INSTANCE, ClusterEventListener.NO_OP) {
-            public CompletableFuture getConnectionAsync(Intent intent, int slot) {
+            public CompletableFuture getConnectionAsync(ConnectionIntent connectionIntent, int slot) {
                 return connectionFuture;
             }
         });


### PR DESCRIPTION
…ConnectionProvider

Refactored Intent to be a top level public enum.
Refactored usages & comments.

https://github.com/lettuce-io/lettuce-core/issues/2095
