### PR TITLE
Fix INFO response parsing when line breaks are CR-LF

### DIFF
--- a/src/test/java/io/lettuce/core/cluster/topology/NodeTopologyViewsUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/topology/NodeTopologyViewsUnitTests.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Arrays;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.lettuce.core.RedisURI;
@@ -65,4 +66,18 @@ class NodeTopologyViewsUnitTests {
         assertThatThrownBy(() -> new NodeTopologyView(localhost, viewByLocalhost, "", 0).getOwnPartition()).isInstanceOf(
                 IllegalStateException.class);
     }
+
+    @Test
+    void infoParsingShouldNotFailWithWindowsPaths() {
+        RedisURI localhost = RedisURI.create("127.0.0.1", 6479);
+        String viewByLocalhost = "1 127.0.0.1:6479 master - 0 1401258245007 2 connected 8000-11999\n";
+        String info = "executable:c:\\users\\user~1.after\\appdata\\local\\temp\\1657742252598-0\\redis-server-7.0.2.exe\n" +
+                "connected_clients:2\n" +
+                "config_file:C:\\Users\\user~1.after\\AppData\\Local\\Temp\\redis-server_496893189609231874520793.conf\n" +
+                "master_repl_offset:5\n";
+        NodeTopologyView nodeTopologyView = new NodeTopologyView(localhost, viewByLocalhost, info, 0);
+        Assertions.assertEquals(2,  nodeTopologyView.getConnectedClients());
+        Assertions.assertEquals(5, nodeTopologyView.getReplicationOffset());
+    }
+
 }


### PR DESCRIPTION
INFO command parsing inside NodeTopologyView throws when encountering '\\' characters due to the use of the Java Property parser. This happens when using some Redis on Windows forks due to the Windows path separator being '\\'.

I think Windows Redis Fork support is not a critical goal, but the class wasn't using the properties that caused the exception in the first place, so I think this makes sense even as a refactor.

A regression unit test case is included for this change.

Fixes #2161.