### PR TITLE
Avoid `PartitionSelectorException` during refresh

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/models/partitions/Partitions.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/Partitions.java
@@ -164,9 +164,8 @@ public class Partitions implements Collection<RedisClusterNode> {
 
         synchronized (partitions) {
 
-            invalidateCache();
-
             if (partitions.isEmpty()) {
+                invalidateCache();
                 return;
             }
 


### PR DESCRIPTION
To solve #2178, this PR moves invalidateCache() in the if clause below. Currently, we encounter `PartitionSelectorException` when cluster topology is refreshing.

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
