### PR TITLE
Use `AttributeKey.valueOf(…)` instead of `AttributeKey.newInstance`

### DIFF
--- a/src/main/java/io/lettuce/core/ConnectionBuilder.java
+++ b/src/main/java/io/lettuce/core/ConnectionBuilder.java
@@ -59,7 +59,7 @@ public class ConnectionBuilder {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ConnectionBuilder.class);
 
-    public static final AttributeKey<String> REDIS_URI = AttributeKey.newInstance("RedisURI");
+    public static final AttributeKey<String> REDIS_URI = AttributeKey.valueOf("RedisURI");
 
     private Mono<SocketAddress> socketAddressSupplier;
 


### PR DESCRIPTION
Changed the method to make sure that it calls getOrCreate instead of createOrThrow
