### PR TITLE
Fix duplicate word occurences

### DIFF
--- a/src/main/java/io/lettuce/core/ConcurrentLruCache.java
+++ b/src/main/java/io/lettuce/core/ConcurrentLruCache.java
@@ -171,7 +171,7 @@ class ConcurrentLruCache<K, V> {
     }
 
     /**
-     * Return the the maximum number of entries in the cache (0 indicates no caching, always generating a new value).
+     * Return the maximum number of entries in the cache (0 indicates no caching, always generating a new value).
      *
      * @see #size()
      */

--- a/src/main/java/io/lettuce/core/SocketOptions.java
+++ b/src/main/java/io/lettuce/core/SocketOptions.java
@@ -324,7 +324,7 @@ public class SocketOptions {
             }
 
             /**
-             * Set the the maximum number of keepalive probes TCP should send before dropping the connection. Defaults to
+             * Set the maximum number of keepalive probes TCP should send before dropping the connection. Defaults to
              * {@code 9}. See also {@link #DEFAULT_COUNT} and {@code TCP_KEEPCNT}.
              *
              * @param count the maximum number of keepalive probes TCP

--- a/src/main/java/io/lettuce/core/metrics/MetricCollector.java
+++ b/src/main/java/io/lettuce/core/metrics/MetricCollector.java
@@ -33,7 +33,7 @@ public interface MetricCollector<T> {
     /**
      * Returns the collected/aggregated metrics.
      *
-     * @return the the collected/aggregated metrics
+     * @return the collected/aggregated metrics
      */
     T retrieveMetrics();
 

--- a/src/main/java/io/lettuce/core/protocol/CommandWrapper.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandWrapper.java
@@ -264,7 +264,7 @@ public class CommandWrapper<K, V, T> implements RedisCommand<K, V, T>, Completea
      *
      * If the receiver implements the interface then the result is the receiver or a proxy for the receiver. If the receiver is
      * a wrapper and the wrapped object implements the interface then the result is the wrapped object or a proxy for the
-     * wrapped object. Otherwise return the the result of calling <code>unwrap</code> recursively on the wrapped object or a
+     * wrapped object. Otherwise return the result of calling <code>unwrap</code> recursively on the wrapped object or a
      * proxy for that result. If the receiver is not a wrapper and does not implement the interface, then an {@code null} is
      * returned.
      *


### PR DESCRIPTION
Trivial documentation fix for repeated word "the the"
