### PR TITLE
Improve `AdaptiveRefreshTriggeredEvent` to provide the cause and contextual details

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/ClusterTopologyRefreshScheduler.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterTopologyRefreshScheduler.java
@@ -125,7 +125,9 @@ class ClusterTopologyRefreshScheduler implements Runnable, ClusterEventListener 
     public void onAskRedirection() {
 
         if (isEnabled(ClusterTopologyRefreshOptions.RefreshTrigger.ASK_REDIRECT)) {
-            indicateTopologyRefreshSignal();
+            if (indicateTopologyRefreshSignal()) {
+                emitAdaptiveRefreshScheduledEvent(ClusterTopologyRefreshOptions.RefreshTrigger.ASK_REDIRECT);
+            }
         }
     }
 
@@ -134,7 +136,7 @@ class ClusterTopologyRefreshScheduler implements Runnable, ClusterEventListener 
 
         if (isEnabled(ClusterTopologyRefreshOptions.RefreshTrigger.MOVED_REDIRECT)) {
             if (indicateTopologyRefreshSignal()) {
-                emitAdaptiveRefreshScheduledEvent();
+                emitAdaptiveRefreshScheduledEvent(ClusterTopologyRefreshOptions.RefreshTrigger.MOVED_REDIRECT);
             }
         }
     }
@@ -145,7 +147,7 @@ class ClusterTopologyRefreshScheduler implements Runnable, ClusterEventListener 
         if (isEnabled(ClusterTopologyRefreshOptions.RefreshTrigger.PERSISTENT_RECONNECTS)
                 && attempt >= getClusterTopologyRefreshOptions().getRefreshTriggersReconnectAttempts()) {
             if (indicateTopologyRefreshSignal()) {
-                emitAdaptiveRefreshScheduledEvent();
+                emitAdaptiveRefreshScheduledEvent(ClusterTopologyRefreshOptions.RefreshTrigger.PERSISTENT_RECONNECTS);
             }
         }
     }
@@ -155,7 +157,7 @@ class ClusterTopologyRefreshScheduler implements Runnable, ClusterEventListener 
 
         if (isEnabled(ClusterTopologyRefreshOptions.RefreshTrigger.UNCOVERED_SLOT)) {
             if (indicateTopologyRefreshSignal()) {
-                emitAdaptiveRefreshScheduledEvent();
+                emitAdaptiveRefreshScheduledEvent(ClusterTopologyRefreshOptions.RefreshTrigger.UNCOVERED_SLOT);
             }
         }
     }
@@ -165,14 +167,15 @@ class ClusterTopologyRefreshScheduler implements Runnable, ClusterEventListener 
 
         if (isEnabled(ClusterTopologyRefreshOptions.RefreshTrigger.UNKNOWN_NODE)) {
             if (indicateTopologyRefreshSignal()) {
-                emitAdaptiveRefreshScheduledEvent();
+                emitAdaptiveRefreshScheduledEvent(ClusterTopologyRefreshOptions.RefreshTrigger.UNKNOWN_NODE);
             }
         }
     }
 
-    private void emitAdaptiveRefreshScheduledEvent() {
+    private void emitAdaptiveRefreshScheduledEvent(ClusterTopologyRefreshOptions.RefreshTrigger trigger) {
+        logger.debug("Adaptive refresh event due to: {}", trigger);
 
-        AdaptiveRefreshTriggeredEvent event = new AdaptiveRefreshTriggeredEvent(partitions, this::scheduleRefresh);
+        AdaptiveRefreshTriggeredEvent event = new AdaptiveRefreshTriggeredEvent(partitions, this::scheduleRefresh, trigger);
 
         clientResources.eventBus().publish(event);
     }

--- a/src/main/java/io/lettuce/core/event/cluster/AdaptiveRefreshTriggeredEvent.java
+++ b/src/main/java/io/lettuce/core/event/cluster/AdaptiveRefreshTriggeredEvent.java
@@ -17,6 +17,7 @@ package io.lettuce.core.event.cluster;
 
 import java.util.function.Supplier;
 
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.event.Event;
 
@@ -31,10 +32,13 @@ public class AdaptiveRefreshTriggeredEvent implements Event {
     private final Supplier<Partitions> partitionsSupplier;
 
     private final Runnable topologyRefreshScheduler;
+    private final ClusterTopologyRefreshOptions.RefreshTrigger refreshTrigger;
 
-    public AdaptiveRefreshTriggeredEvent(Supplier<Partitions> partitionsSupplier, Runnable topologyRefreshScheduler) {
+    public AdaptiveRefreshTriggeredEvent(Supplier<Partitions> partitionsSupplier, Runnable topologyRefreshScheduler,
+                                         ClusterTopologyRefreshOptions.RefreshTrigger refreshTrigger) {
         this.partitionsSupplier = partitionsSupplier;
         this.topologyRefreshScheduler = topologyRefreshScheduler;
+        this.refreshTrigger = refreshTrigger;
     }
 
     /**
@@ -53,4 +57,10 @@ public class AdaptiveRefreshTriggeredEvent implements Event {
         return partitionsSupplier.get();
     }
 
+    /**
+     * Retrieve the {@link ClusterTopologyRefreshOptions.RefreshTrigger} that caused this event.
+     */
+    public ClusterTopologyRefreshOptions.RefreshTrigger getRefreshTrigger() {
+        return refreshTrigger;
+    }
 }


### PR DESCRIPTION
What:

- Adds trigger source to the `AdaptiveRefreshTriggeredEvent` class.
- Adds debug logging for the event.
- Adds missing event for the `ASK_REDIRECT` trigger (I'm assuming this was missing by mistake?).

Why:

I have recently been trying to debug excessive topology refreshes, and found it very difficult to find the root cause.