### PR TITLE
Fix Set unit test sscanMultiple fail in redis7

### DIFF
--- a/src/test/java/io/lettuce/core/commands/SetCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/SetCommandIntegrationTests.java
@@ -358,7 +358,7 @@ public class SetCommandIntegrationTests extends TestSupport {
 
         Set<String> expect = new HashSet<>();
         Set<String> check = new HashSet<>();
-        setup100KeyValues(expect);
+        setup129KeyValues(expect);
 
         ValueScanCursor<String> cursor = redis.sscan(key, ScanArgs.Builder.limit(5));
 
@@ -379,18 +379,20 @@ public class SetCommandIntegrationTests extends TestSupport {
     void scanMatch() {
 
         Set<String> expect = new HashSet<>();
-        setup100KeyValues(expect);
+        setup129KeyValues(expect);
 
         ValueScanCursor<String> cursor = redis.sscan(key, ScanArgs.Builder.limit(200).match("value1*"));
 
         assertThat(cursor.getCursor()).isEqualTo("0");
         assertThat(cursor.isFinished()).isTrue();
 
-        assertThat(cursor.getValues()).hasSize(11);
+        assertThat(cursor.getValues()).hasSize(40);
     }
 
-    void setup100KeyValues(Set<String> expect) {
-        for (int i = 0; i < 100; i++) {
+    void setup129KeyValues(Set<String> expect) {
+        // Redis 7.0 introduce listpack, and `set-max-listpack-entries` is 128
+        // so we add 129 elements to convert it to hashtable
+        for (int i = 0; i < 129; i++) {
             redis.sadd(key, value + i);
             expect.add(value + i);
         }


### PR DESCRIPTION
Before this pr, `sscanMultiple` will fail at `assertThat(cursor.getCursor()).isNotNull().isNotEqualTo("0");`, because the bottom layer is the ListPack([set_max_listpack_entries](https://github.com/redis/redis/blob/unstable/src/config.c#L3176) default is 128) structure at this time. It does not support the count option. It will return all values and set the CURSOR to 0.

see https://redis.io/commands/scan/  *Why SCAN may return all the items of an aggregate data type in a single call?* for more info.

This PR also runs successfully on versions prior to 7.0 without incompatibility.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
