### PR TITLE
Fix the RedisPublisher.RedisSubscription#potentiallyReadMore demand long overflow bug

### DIFF
--- a/src/main/java/io/lettuce/core/RedisPublisher.java
+++ b/src/main/java/io/lettuce/core/RedisPublisher.java
@@ -15,22 +15,6 @@
  */
 package io.lettuce.core;
 
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Supplier;
-
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-
-import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
-import reactor.util.context.Context;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.internal.ExceptionFactory;
@@ -43,6 +27,21 @@ import io.netty.util.Recycler;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.util.context.Context;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
 
 /**
  * Reactive command {@link Publisher} using ReactiveStreams.
@@ -408,7 +407,11 @@ class RedisPublisher<K, V, T> implements Publisher<T> {
 
         void potentiallyReadMore() {
 
-            if ((getDemand() + 1) > data.size()) {
+            /*
+             * getDemand() maybe is Long.MAX_VALUE，because MonoNext.NextSubscriber#request(long n) inner use the Long.MAX_VALUE,
+             * so maybe "getDemand() + 1" will be overflow，we use "getDemand() > data.size() - 1" replace the "(getDemand() + 1) > data.size()"
+             */
+            if (getDemand() > data.size() - 1) {
                 state().readData(this);
             }
         }

--- a/src/main/java/io/lettuce/core/RedisPublisher.java
+++ b/src/main/java/io/lettuce/core/RedisPublisher.java
@@ -15,6 +15,22 @@
  */
 package io.lettuce.core;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.util.context.Context;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.internal.ExceptionFactory;
@@ -27,21 +43,6 @@ import io.netty.util.Recycler;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
-import reactor.util.context.Context;
-
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Supplier;
 
 /**
  * Reactive command {@link Publisher} using ReactiveStreams.


### PR DESCRIPTION
getDemand() maybe is Long.MAX_VALUE，because MonoNext.NextSubscriber#request(long n) inner use the Long.MAX_VALUE, so maybe "getDemand() + 1" will be overflow，we use "getDemand() > data.size() - 1" replace the "(getDemand() + 1) > data.size()"

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
![image](https://user-images.githubusercontent.com/6687462/232313133-af731dbe-63cf-45a0-a820-6de6c5f6ac33.png)

![image](https://user-images.githubusercontent.com/6687462/232313075-16dfdf27-5c30-4873-9845-e5e532af0104.png)
