### PR TITLE
Allow dash symbol in parsing slave IP of replication INFO response

### DIFF
--- a/src/main/java/io/lettuce/core/masterreplica/ReplicaTopologyProvider.java
+++ b/src/main/java/io/lettuce/core/masterreplica/ReplicaTopologyProvider.java
@@ -43,7 +43,7 @@ class ReplicaTopologyProvider implements TopologyProvider {
 
     public static final Pattern ROLE_PATTERN = Pattern.compile("^role\\:([a-z]+)$", Pattern.MULTILINE);
 
-    public static final Pattern SLAVE_PATTERN = Pattern.compile("^slave(\\d+)\\:([a-zA-Z\\,\\=\\d\\.\\:]+)$",
+    public static final Pattern SLAVE_PATTERN = Pattern.compile("^slave(\\d+)\\:([a-zA-Z\\,\\=\\d\\.\\:\\-]+)$",
             Pattern.MULTILINE);
 
     public static final Pattern MASTER_HOST_PATTERN = Pattern.compile("^master_host\\:([a-zA-Z\\,\\=\\d\\.\\:\\-]+)$",
@@ -51,7 +51,7 @@ class ReplicaTopologyProvider implements TopologyProvider {
 
     public static final Pattern MASTER_PORT_PATTERN = Pattern.compile("^master_port\\:(\\d+)$", Pattern.MULTILINE);
 
-    public static final Pattern IP_PATTERN = Pattern.compile("ip\\=([a-zA-Z\\d\\.\\:]+)");
+    public static final Pattern IP_PATTERN = Pattern.compile("ip\\=([a-zA-Z\\d\\.\\:\\-]+)");
 
     public static final Pattern PORT_PATTERN = Pattern.compile("port\\=([\\d]+)");
 

--- a/src/test/java/io/lettuce/core/masterreplica/MasterReplicaTopologyProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/masterreplica/MasterReplicaTopologyProviderUnitTests.java
@@ -130,11 +130,12 @@ class MasterReplicaTopologyProviderUnitTests {
 
         String info = "# Replication\r\n" + "role:master\r\n"
                 + "slave0:ip=127.0.0.1,port=6483,state=online,offset=56276,lag=0\r\n"
-                + "slave1:ip=127.0.0.1,port=6484,state=online,offset=56276,lag=0\r\n" + "master_repl_offset:56276\r\n"
+                + "slave1:ip=127.0.0.1,port=6484,state=online,offset=56276,lag=0\r\n"
+                + "slave2:ip=redis-replica-2.,port=6484,state=online,offset=56276,lag=0\r\n" + "master_repl_offset:56276\r\n"
                 + "repl_backlog_active:1\r\n";
 
         List<RedisNodeDescription> result = sut.getNodesFromInfo(info);
-        assertThat(result).hasSize(3);
+        assertThat(result).hasSize(4);
 
         RedisNodeDescription replica1 = result.get(1);
 
@@ -147,6 +148,12 @@ class MasterReplicaTopologyProviderUnitTests {
         assertThat(replica2.getRole()).isEqualTo(RedisInstance.Role.SLAVE);
         assertThat(replica2.getUri().getHost()).isEqualTo("127.0.0.1");
         assertThat(replica2.getUri().getPort()).isEqualTo(6484);
+
+        RedisNodeDescription replica3 = result.get(3);
+
+        assertThat(replica3.getRole()).isEqualTo(RedisInstance.Role.SLAVE);
+        assertThat(replica3.getUri().getHost()).isEqualTo("redis-replica-2.");
+        assertThat(replica3.getUri().getPort()).isEqualTo(6484);
     }
 
     @Test


### PR DESCRIPTION
Replication info command parsing can't parse slave IP if the dash symbol is contained.
Fixes [#2375](https://github.com/lettuce-io/lettuce-core/issues/2375)