### PR TITLE
Fix to run commands of MGET in parallel

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -284,7 +284,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
             publishers.add(super.mget(entry.getValue()));
         }
 
-        Flux<KeyValue<K, V>> fluxes = Flux.concat(publishers);
+        Flux<KeyValue<K, V>> fluxes = Flux.mergeSequential(publishers);
 
         Mono<List<KeyValue<K, V>>> map = fluxes.collectList().map(vs -> {
 


### PR DESCRIPTION
The purpose of this PR is to allow reactive mget commands for Redis clusters to run in parallel.
Fixes https://github.com/lettuce-io/lettuce-core/issues/2395
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
