### PR TITLE
bump netty version to address security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <micrometer.version>1.10.6</micrometer.version>
         <micrometer-tracing.version>1.0.4</micrometer-tracing.version>
         <mockito.version>4.9.0</mockito.version>
-        <netty.version>4.1.91.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
         <openwebbeans.version>2.0.27</openwebbeans.version>
         <reactor.version>3.4.29</reactor.version>
         <rxjava.version>1.3.8</rxjava.version>


### PR DESCRIPTION
This is to use the latest netty version that fixed the security vulnerability in netty packages. 
Having a new release with the latest netty package would be very helpful. Thank you very much.

The security vulnerability report: https://github.com/netty/netty/security/advisories/GHSA-6mjq-h674-j845
 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
