### PR TITLE
Fix NPE when manually flushing a batch

### DIFF
--- a/src/main/java/io/lettuce/core/dynamic/SimpleBatcher.java
+++ b/src/main/java/io/lettuce/core/dynamic/SimpleBatcher.java
@@ -35,6 +35,7 @@ import io.lettuce.core.protocol.RedisCommand;
  * </ul>
  *
  * @author Mark Paluch
+ * @author Lucio Paiva
  */
 class SimpleBatcher implements Batcher {
 
@@ -148,12 +149,12 @@ class SimpleBatcher implements Batcher {
 
         List<RedisCommand<Object, Object, Object>> batch = new ArrayList<>(Math.max(batchSize, 10));
 
-        do {
+        while (!queue.isEmpty()) {
+
             RedisCommand<Object, Object, Object> poll = queue.poll();
 
-            assert poll != null;
             batch.add(poll);
-        } while (!queue.isEmpty());
+        }
 
         return batch;
     }
@@ -166,7 +167,6 @@ class SimpleBatcher implements Batcher {
 
             RedisCommand<Object, Object, Object> poll = queue.poll();
 
-            assert poll != null;
             batch.add(poll);
         }
 

--- a/src/test/java/io/lettuce/core/dynamic/RedisCommandsBatchingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/RedisCommandsBatchingIntegrationTests.java
@@ -42,6 +42,7 @@ import io.lettuce.test.TestFutures;
 
 /**
  * @author Mark Paluch
+ * @author Lucio Paiva
  */
 @ExtendWith(LettuceExtension.class)
 class RedisCommandsBatchingIntegrationTests extends TestSupport {
@@ -97,6 +98,16 @@ class RedisCommandsBatchingIntegrationTests extends TestSupport {
             assertThat(redis.get("k1")).isEqualTo(value);
             assertThat(e.getFailedCommands()).hasSize(1);
         }
+    }
+
+    @Test
+    void shouldNotCrashWhenFlushCalledWithEmptyQueue() {
+
+        RedisCommandFactory factory = new RedisCommandFactory(redis.getStatefulConnection());
+
+        SelectiveBatchingWithSize api = factory.getCommands(SelectiveBatchingWithSize.class);
+
+        api.flush();
     }
 
     @Test
@@ -212,6 +223,11 @@ class RedisCommandsBatchingIntegrationTests extends TestSupport {
         void set(String key, String value, CommandBatching commandBatching);
 
         void llen(String key, CommandBatching commandBatching);
+
+    }
+
+    @BatchSize(5)
+    interface SelectiveBatchingWithSize extends Commands, BatchExecutor {
 
     }
 


### PR DESCRIPTION
When manually flushing a batch with a set size, we can potentially run into a NPE if the command queue is empty when flush() is called. This PR is fixing that.

I ran into this problem while working on a code that sends commands to Redis in batches. In my code I defined an interface like this:

```java
@BatchSize(100)
public interface MyCommands extends Commands, BatchExecutor {

    public void set(String key, String value);
}
```

For each batch, no matter how many commands it has, I want to make sure that it flushes the commands as soon as I finish enqueuing them, like this:

```java
for (int i = 0; i < myBatchSize; i++) {
    api.set(key[i], value[i]);
}
api.flush();
```

And that's when I ran into a problem: when `myBatchSize == 100`, after the 100th is enqueued a flush is automatically triggered because of `@BatchSize(100)`, and the queue gets emptied. Right after, `api.flush()` is called and Lettuce raises a NPE.

A simpler way to reproduce the problem is to just call `flush()` without ever enqueueing anything, so that's what I did in the test that I wrote.

The fix is really simple and just involves replacing a `do..while` with a `while` block that first checks if the queue is empty before trying to poll from it.

The bug is there since at least 5.2 (the earliest version I tested).

---

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
