### PR TITLE
Support for module-based read-only commands #2401

### DIFF
--- a/src/main/java/io/lettuce/core/masterreplica/AutodiscoveryConnector.java
+++ b/src/main/java/io/lettuce/core/masterreplica/AutodiscoveryConnector.java
@@ -39,6 +39,7 @@ import io.lettuce.core.models.role.RedisNodeDescription;
  * a single {@link RedisURI}.
  *
  * @author Mark Paluch
+ * @author Jim Brunner
  * @since 5.1
  */
 class AutodiscoveryConnector<K, V> implements MasterReplicaConnector<K, V> {
@@ -125,8 +126,7 @@ class AutodiscoveryConnector<K, V> implements MasterReplicaConnector<K, V> {
 
             connectionProvider.setKnownNodes(nodes);
 
-            MasterReplicaChannelWriter channelWriter = new MasterReplicaChannelWriter(connectionProvider,
-                    redisClient.getResources());
+            MasterReplicaChannelWriter channelWriter = new MasterReplicaChannelWriter(connectionProvider, redisClient.getResources(), redisClient.getOptions());
 
             StatefulRedisMasterReplicaConnectionImpl<K, V> connection = new StatefulRedisMasterReplicaConnectionImpl<>(
                     channelWriter, codec, redisURI.getTimeout());

--- a/src/main/java/io/lettuce/core/masterreplica/SentinelConnector.java
+++ b/src/main/java/io/lettuce/core/masterreplica/SentinelConnector.java
@@ -35,6 +35,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * {@link MasterReplicaConnector} to connect a Sentinel-managed Master/Replica setup using a Sentinel {@link RedisURI}.
  *
  * @author Mark Paluch
+ * @author Jim Brunner
  * @since 5.1
  */
 class SentinelConnector<K, V> implements MasterReplicaConnector<K, V> {
@@ -83,7 +84,7 @@ class SentinelConnector<K, V> implements MasterReplicaConnector<K, V> {
         connectionProvider.setKnownNodes(nodes);
 
         MasterReplicaChannelWriter channelWriter = new MasterReplicaChannelWriter(connectionProvider,
-                redisClient.getResources()) {
+                redisClient.getResources(), redisClient.getOptions()) {
 
             @Override
             public CompletableFuture<Void> closeAsync() {

--- a/src/main/java/io/lettuce/core/masterreplica/StaticMasterReplicaConnector.java
+++ b/src/main/java/io/lettuce/core/masterreplica/StaticMasterReplicaConnector.java
@@ -35,6 +35,7 @@ import io.lettuce.core.models.role.RedisNodeDescription;
  * {@link RedisURI}. This connector determines roles and remains using only the provided endpoints.
  *
  * @author Mark Paluch
+ * @author Jim Brunner
  * @since 5.1
  */
 class StaticMasterReplicaConnector<K, V> implements MasterReplicaConnector<K, V> {
@@ -81,8 +82,7 @@ class StaticMasterReplicaConnector<K, V> implements MasterReplicaConnector<K, V>
 
         connectionProvider.setKnownNodes(nodes);
 
-        MasterReplicaChannelWriter channelWriter = new MasterReplicaChannelWriter(connectionProvider,
-                redisClient.getResources());
+        MasterReplicaChannelWriter channelWriter = new MasterReplicaChannelWriter(connectionProvider, redisClient.getResources(), redisClient.getOptions());
 
         StatefulRedisMasterReplicaConnectionImpl<K, V> connection = new StatefulRedisMasterReplicaConnectionImpl<>(
                 channelWriter, codec, seedNode.getTimeout());

--- a/src/test/java/io/lettuce/core/cluster/ClusterDistributionChannelWriterUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterDistributionChannelWriterUnitTests.java
@@ -38,6 +38,7 @@ import org.mockito.quality.Strictness;
 
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.CommandListenerWriter;
+import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -60,6 +61,7 @@ import io.lettuce.core.resource.ClientResources;
  *
  * @author Mark Paluch
  * @author koisyu
+ * @author Jim Brunner
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -73,6 +75,9 @@ class ClusterDistributionChannelWriterUnitTests {
 
     @Mock
     private ClientResources clientResources;
+
+    @Mock
+    private ClientOptions clientOptions;
 
     @Mock
     private ClusterEventListener clusterEventListener;
@@ -159,40 +164,48 @@ class ClusterDistributionChannelWriterUnitTests {
     @Test
     void shouldReturnIntentForWriteCommand() {
 
+        ClusterDistributionChannelWriter writer = new ClusterDistributionChannelWriter(clusterDistributionChannelWriter, clientOptions, clusterEventListener);
+
         RedisCommand<String, String, String> set = new Command<>(CommandType.SET, null);
         RedisCommand<String, String, String> mset = new Command<>(CommandType.MSET, null);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(set, mset))).isEqualTo(ConnectionIntent.WRITE);
+        assertThat(writer.getIntent(Arrays.asList(set, mset))).isEqualTo(ConnectionIntent.WRITE);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(set))).isEqualTo(ConnectionIntent.WRITE);
+        assertThat(writer.getIntent(Collections.singletonList(set))).isEqualTo(ConnectionIntent.WRITE);
     }
 
     @Test
     void shouldReturnDefaultIntentForNoCommands() {
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.emptyList())).isEqualTo(ConnectionIntent.WRITE);
+        ClusterDistributionChannelWriter writer = new ClusterDistributionChannelWriter(clusterDistributionChannelWriter, clientOptions, clusterEventListener);
+
+        assertThat(writer.getIntent(Collections.emptyList())).isEqualTo(ConnectionIntent.WRITE);
     }
 
     @Test
     void shouldReturnIntentForReadCommand() {
 
+        ClusterDistributionChannelWriter writer = new ClusterDistributionChannelWriter(clusterDistributionChannelWriter, clientOptions, clusterEventListener);
+
         RedisCommand<String, String, String> get = new Command<>(CommandType.GET, null);
         RedisCommand<String, String, String> mget = new Command<>(CommandType.MGET, null);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(get, mget))).isEqualTo(ConnectionIntent.READ);
+        assertThat(writer.getIntent(Arrays.asList(get, mget))).isEqualTo(ConnectionIntent.READ);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(get))).isEqualTo(ConnectionIntent.READ);
+        assertThat(writer.getIntent(Collections.singletonList(get))).isEqualTo(ConnectionIntent.READ);
     }
 
     @Test
     void shouldReturnIntentForMixedCommands() {
 
+        ClusterDistributionChannelWriter writer = new ClusterDistributionChannelWriter(clusterDistributionChannelWriter, clientOptions, clusterEventListener);
+
         RedisCommand<String, String, String> set = new Command<>(CommandType.SET, null);
         RedisCommand<String, String, String> mget = new Command<>(CommandType.MGET, null);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Arrays.asList(set, mget))).isEqualTo(ConnectionIntent.WRITE);
+        assertThat(writer.getIntent(Arrays.asList(set, mget))).isEqualTo(ConnectionIntent.WRITE);
 
-        assertThat(ClusterDistributionChannelWriter.getIntent(Collections.singletonList(set))).isEqualTo(ConnectionIntent.WRITE);
+        assertThat(writer.getIntent(Collections.singletonList(set))).isEqualTo(ConnectionIntent.WRITE);
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Mark,

Looking for feedback on this.  At this point, I've authored the code changes, but no unit/integration tests have been written.

A few questions:
1. Is this what you were envisioning?  If not, what needs to be improved?
2. I'm not completely happy with the `extraReadOnlyCommands`.  I'd really rather do something that also pulls in the standard read-only commands and combines the functionality directly.  I also wasn't sure that this is what you were expecting.
  * I thought about overriding `ClientOptions` logic in the `ClusterClientOptions` to automatically pick up the cluster read-only commands - however from the existing code in `ClusterDistributionChannelWriter` (the constructor), it seems that we can't trust that the `ClusterClientOptions` is guaranteed to be used.  I the end, I decided that some "extra" commands added in `ClientOptions` - with logic remaining the the channel writers was the most straightforward.
3.  What do we need in terms of test cases?


