### PR TITLE
Add io.lettuce.core.metrics.DefaultCommandLatencyCollector$DefaultPauseDetectorWrapper to the initialize-at-build-time arg

### DIFF
--- a/src/main/resources/META-INF/native-image/io.lettuce/lettuce-core/native-image.properties
+++ b/src/main/resources/META-INF/native-image/io.lettuce/lettuce-core/native-image.properties
@@ -1,1 +1,1 @@
-Args=--initialize-at-build-time=io.lettuce.core.metrics.DefaultCommandLatencyCollector,io.lettuce.core.metrics.DefaultCommandLatencyCollector$NoOpPauseDetectorWrapper,io.lettuce.core.internal.LettuceClassUtils
+Args=--initialize-at-build-time=io.lettuce.core.metrics.DefaultCommandLatencyCollector,io.lettuce.core.metrics.DefaultCommandLatencyCollector$NoOpPauseDetectorWrapper,io.lettuce.core.metrics.DefaultCommandLatencyCollector$DefaultPauseDetectorWrapper,io.lettuce.core.internal.LettuceClassUtils


### PR DESCRIPTION
Fixes #2579