### PR TITLE
Add `@Nullable`

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/RedisCommand.java
+++ b/src/main/java/io/lettuce/core/protocol/RedisCommand.java
@@ -15,6 +15,7 @@
  */
 package io.lettuce.core.protocol;
 
+import reactor.util.annotation.Nullable;
 import io.lettuce.core.output.CommandOutput;
 import io.netty.buffer.ByteBuf;
 
@@ -62,6 +63,7 @@ public interface RedisCommand<K, V, T> {
     /**
      * @return the current command args.
      */
+    @Nullable
     CommandArgs<K, V> getArgs();
 
     /**


### PR DESCRIPTION
I am utilizing RedisCommand in CommandListener.

However, in the case of MULTI, an NPE occurs when CommandArgs is referenced. But there is no explanation for this. I thought it would be very useful to have `@Nullable` to recognize this, so I created a pull request.