### PR TITLE
Eliminate unnecessary expensive size() calls, use ConcurrentLinkedQueue instead of ConcurrentLinkedDeque

### DIFF
--- a/src/main/java/io/lettuce/core/internal/LettuceFactories.java
+++ b/src/main/java/io/lettuce/core/internal/LettuceFactories.java
@@ -20,7 +20,7 @@ import java.util.Deque;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
@@ -35,19 +35,19 @@ public class LettuceFactories {
      * Threshold used to determine queue implementation. A queue size above the size indicates usage of
      * {@link LinkedBlockingQueue} otherwise {@link ArrayBlockingQueue}.
      */
-    private static final int ARRAY_QUEUE_THRESHOLD = Integer
-            .getInteger("io.lettuce.core.LettuceFactories.array-queue-threshold", 200000);
+    private static final int ARRAY_QUEUE_THRESHOLD = Integer.getInteger(
+            "io.lettuce.core.LettuceFactories.array-queue-threshold", 200000);
 
     /**
      * Creates a new, optionally bounded, {@link Queue} that does not require external synchronization.
      *
-     * @param maxSize queue size. If {@link Integer#MAX_VALUE}, then creates an {@link ConcurrentLinkedDeque unbounded queue}.
+     * @param maxSize queue size. If {@link Integer#MAX_VALUE}, then creates an {@link ConcurrentLinkedQueue unbounded queue}.
      * @return a new, empty {@link Queue}.
      */
     public static <T> Queue<T> newConcurrentQueue(int maxSize) {
 
         if (maxSize == Integer.MAX_VALUE) {
-            return new ConcurrentLinkedDeque<>();
+            return new ConcurrentLinkedQueue<>();
         }
 
         return maxSize > ARRAY_QUEUE_THRESHOLD ? new LinkedBlockingQueue<>(maxSize) : new ArrayBlockingQueue<>(maxSize);

--- a/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
+++ b/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
@@ -63,11 +63,11 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
 
     private static final AtomicLong ENDPOINT_COUNTER = new AtomicLong();
 
-    private static final AtomicIntegerFieldUpdater<DefaultEndpoint> QUEUE_SIZE = AtomicIntegerFieldUpdater
-            .newUpdater(DefaultEndpoint.class, "queueSize");
+    private static final AtomicIntegerFieldUpdater<DefaultEndpoint> QUEUE_SIZE = AtomicIntegerFieldUpdater.newUpdater(
+            DefaultEndpoint.class, "queueSize");
 
-    private static final AtomicIntegerFieldUpdater<DefaultEndpoint> STATUS = AtomicIntegerFieldUpdater
-            .newUpdater(DefaultEndpoint.class, "status");
+    private static final AtomicIntegerFieldUpdater<DefaultEndpoint> STATUS = AtomicIntegerFieldUpdater.newUpdater(
+            DefaultEndpoint.class, "status");
 
     private static final int ST_OPEN = 0;
 
@@ -745,8 +745,8 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
 
         List<RedisCommand<?, ?, ?>> target = new ArrayList<>(disconnectedBuffer.size() + commandBuffer.size());
 
-        target.addAll(drainCommands(disconnectedBuffer));
-        target.addAll(drainCommands(commandBuffer));
+        drainCommands(disconnectedBuffer, target);
+        drainCommands(commandBuffer, target);
 
         return target;
     }
@@ -761,6 +761,19 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
 
         List<RedisCommand<?, ?, ?>> target = new ArrayList<>(source.size());
 
+        drainCommands(source, target);
+        return target;
+    }
+
+    /**
+     * Drain commands from a queue and return only active commands.
+     *
+     * @param source the source queue.
+     * @return List of commands.
+     */
+    private static void drainCommands(Queue<? extends RedisCommand<?, ?, ?>> source,
+            List<RedisCommand<?, ?, ?>> target) {
+
         RedisCommand<?, ?, ?> cmd;
         while ((cmd = source.poll()) != null) {
 
@@ -768,8 +781,6 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
                 target.add(cmd);
             }
         }
-
-        return target;
     }
 
     private void cancelBufferedCommands(String message) {


### PR DESCRIPTION
perf: eliminate unnecessary expensive size() calls, use ConcurrentLinkedQueue instead of ConcurrentLinkedDeque)

refer to https://github.com/lettuce-io/lettuce-core/issues/2602

- [Y] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [Y] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [Y] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [Y] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
