### PR TITLE
Remove State allocs in `RedisStateMachine` and reduce allocs in `ByteArrayCodec`

### DIFF
--- a/src/main/java/io/lettuce/core/codec/ByteArrayCodec.java
+++ b/src/main/java/io/lettuce/core/codec/ByteArrayCodec.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
  * A {@link RedisCodec} that uses plain byte arrays without further transformations.
  *
  * @author Mark Paluch
+ * @author shikharid
  * @since 3.3
  */
 public class ByteArrayCodec implements RedisCodec<byte[], byte[]>, ToByteBufEncoder<byte[], byte[]> {
@@ -52,6 +53,11 @@ public class ByteArrayCodec implements RedisCodec<byte[], byte[]>, ToByteBufEnco
         }
 
         return ((byte[]) keyOrValue).length;
+    }
+
+    @Override
+    public boolean isEstimateExact() {
+        return true;
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/codec/ToByteBufEncoder.java
+++ b/src/main/java/io/lettuce/core/codec/ToByteBufEncoder.java
@@ -27,6 +27,7 @@ import io.netty.buffer.ByteBuf;
  * </p>
  *
  * @author Mark Paluch
+ * @author shikharid
  * @since 4.3
  */
 public interface ToByteBufEncoder<K, V> {
@@ -55,5 +56,15 @@ public interface ToByteBufEncoder<K, V> {
      * @return the estimated number of bytes in the encoded representation.
      */
     int estimateSize(Object keyOrValue);
+
+    /**
+     * Returns true if {@link ToByteBufEncoder#estimateSize(Object)} returns exact size
+     * This is used as an optimisation to reduce memory allocations when encoding data
+     *
+     * @return true if {@link ToByteBufEncoder#estimateSize(Object)} returns exact size
+     */
+    default boolean isEstimateExact() {
+        return false;
+    }
 
 }

--- a/src/test/jmh/io/lettuce/core/cluster/ClusterDistributionChannelWriterBenchmark.java
+++ b/src/test/jmh/io/lettuce/core/cluster/ClusterDistributionChannelWriterBenchmark.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import io.lettuce.core.protocol.ConnectionIntent;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -69,7 +70,7 @@ public class ClusterDistributionChannelWriterBenchmark {
     @Setup
     public void setup() {
 
-        writer = new ClusterDistributionChannelWriter(CLIENT_OPTIONS, EMPTY_WRITER, ClusterEventListener.NO_OP);
+        writer = new ClusterDistributionChannelWriter(EMPTY_WRITER, CLIENT_OPTIONS, ClusterEventListener.NO_OP);
 
         Partitions partitions = new Partitions();
 

--- a/src/test/jmh/io/lettuce/core/codec/ExactVsEstimatedSizeCodecBenchmark.java
+++ b/src/test/jmh/io/lettuce/core/codec/ExactVsEstimatedSizeCodecBenchmark.java
@@ -1,0 +1,89 @@
+package io.lettuce.core.codec;
+
+import io.lettuce.core.protocol.CommandArgs;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import org.checkerframework.checker.units.qual.C;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark to measure perf gains when codec knows the exact byte size when encoding args
+ *
+ * @author shikharid
+ */
+public class ExactVsEstimatedSizeCodecBenchmark {
+
+    @Benchmark
+    public void encodeKeyExactSize(Input input, Blackhole blackhole) {
+        encodeKey(input.testBytes, ByteArrayCodec.INSTANCE, input.target);
+        blackhole.consume(input.target);
+        input.target.clear();
+    }
+
+    @Benchmark
+    public void encodeKeyEstimatedSize(Input input, Blackhole blackhole) {
+        encodeKey(input.testBytes, EstimatedSizeByteArrayCodec.INSTANCE, input.target);
+        blackhole.consume(input.target);
+        input.target.clear();
+    }
+
+    @Benchmark
+    public void encodeValueExactSize(Input input, Blackhole blackhole) {
+        encodeValue(input.testBytes, ByteArrayCodec.INSTANCE, input.target);
+        blackhole.consume(input.target);
+        input.target.clear();
+    }
+
+    @Benchmark
+    public void encodeValueEstimatedSize(Input input, Blackhole blackhole) {
+        encodeValue(input.testBytes, EstimatedSizeByteArrayCodec.INSTANCE, input.target);
+        blackhole.consume(input.target);
+        input.target.clear();
+    }
+
+    private static void encodeKey(byte[] key, RedisCodec<byte[], byte[]> codec, ByteBuf target) {
+        CommandArgs<byte[], byte[]> commandArgs = new CommandArgs<>(codec);
+        commandArgs.addKey(key);
+        commandArgs.encode(target);
+    }
+
+    private static void encodeValue(byte[] value, RedisCodec<byte[], byte[]> codec, ByteBuf target) {
+        CommandArgs<byte[], byte[]> commandArgs = new CommandArgs<>(codec);
+        commandArgs.addValue(value);
+        commandArgs.encode(target);
+    }
+
+    @State(Scope.Thread)
+    public static class Input {
+        final byte[] testBytes = "some (not-so-)random bytes".getBytes();
+
+        /*
+            By default, used an Unpooled heap buffer so that "GC" specific improvements are visible in benchmark thorugh profiling
+
+            But Using a pooled direct buffer gives us the FULL story for most real world uses
+                Most usages are of a direct pooled bytebuf allocator for Netty, Which has its own jemalloc based GC
+
+            Replace this with a pooled direct allocator to see real-world gains
+                Note that GC profiling in that case won't show much diff, as we only save a couple of allocs afa heap is concerned
+                But you will still see the perf gains
+         */
+        final ByteBuf target = Unpooled.buffer(512);
+        //final ByteBuf target = PooledByteBufAllocator.DEFAULT.directBuffer(512);
+    }
+
+    // Emulates older ByteArrayCodec behaviour (no concept of exact estimates)
+    public static class EstimatedSizeByteArrayCodec extends ByteArrayCodec {
+
+        public static final EstimatedSizeByteArrayCodec INSTANCE = new EstimatedSizeByteArrayCodec();
+
+        @Override
+        public boolean isEstimateExact() {
+            return false;
+        }
+
+    }
+}

--- a/src/test/jmh/io/lettuce/core/codec/JmhMain.java
+++ b/src/test/jmh/io/lettuce/core/codec/JmhMain.java
@@ -28,12 +28,14 @@ import org.openjdk.jmh.runner.options.TimeValue;
  * Manual JMH Test Launcher.
  *
  * @author Mark Paluch
+ * @author shikharid
  */
 public class JmhMain {
 
     public static void main(String... args) throws RunnerException {
 
-        runCommandBenchmark();
+        //runCommandBenchmark();
+        runExactVsEstimatedSizeEncoderBenchmark();
     }
 
     private static void runCommandBenchmark() throws RunnerException {
@@ -41,6 +43,21 @@ public class JmhMain {
         new Runner(prepareOptions().mode(Mode.AverageTime) //
                 .timeUnit(TimeUnit.NANOSECONDS) //
                 .include(".*CodecBenchmark.*") //
+                .build()).run();
+    }
+
+    private static void runExactVsEstimatedSizeEncoderBenchmark() throws RunnerException {
+
+        // measure time-per-op
+        new Runner(prepareOptions().mode(Mode.AverageTime).timeUnit(TimeUnit.NANOSECONDS)
+                .include(".*ExactVsEstimatedSizeCodecBenchmark.*")
+                .addProfiler("gc")
+                .build()).run();
+
+        // measure thrpt (ops/sec)
+        new Runner(prepareOptions().mode(Mode.Throughput).timeUnit(TimeUnit.SECONDS)
+                .include(".*ExactVsEstimatedSizeCodecBenchmark.*")
+                .addProfiler("gc")
                 .build()).run();
     }
 

--- a/src/test/jmh/io/lettuce/core/protocol/JmhMain.java
+++ b/src/test/jmh/io/lettuce/core/protocol/JmhMain.java
@@ -35,9 +35,9 @@ public class JmhMain {
 
         // run selectively
         // runCommandBenchmark();
-        runCommandHandlerBenchmark();
+        // runCommandHandlerBenchmark();
         // runRedisEndpointBenchmark();
-        // runRedisStateMachineBenchmark();
+        runRedisStateMachineBenchmark();
         // runCommandEncoderBenchmark();
 
         // or all
@@ -83,14 +83,21 @@ public class JmhMain {
 
     private static void runRedisStateMachineBenchmark() throws RunnerException {
 
-        new Runner(prepareOptions().mode(Mode.AverageTime).timeUnit(TimeUnit.NANOSECONDS)
+        // measures AverageTime in ns (time/op)
+        new Runner(prepareRSMOptions().mode(Mode.AverageTime).timeUnit(TimeUnit.NANOSECONDS)
                 .include(".*RedisStateMachineBenchmark.*").build()).run();
-        // new
-        // Runner(prepareOptions().mode(Mode.Throughput).timeUnit(TimeUnit.SECONDS).include(".*CommandHandlerBenchmark.*").build()).run();
+
+        // measures Throughput (ops/sec)
+        new Runner(prepareRSMOptions().mode(Mode.Throughput).timeUnit(TimeUnit.SECONDS)
+                .include(".*RedisStateMachineBenchmark.*").build()).run();
     }
 
     private static ChainedOptionsBuilder prepareOptions() {
         return new OptionsBuilder().forks(1).warmupIterations(5).threads(1).measurementIterations(5)
                 .timeout(TimeValue.seconds(2));
+    }
+
+    private static ChainedOptionsBuilder prepareRSMOptions() {
+        return prepareOptions().addProfiler("gc");
     }
 }


### PR DESCRIPTION
Two changes:
1. In RedisStateMachine, use pre-allocated State objects
2. For ByteArrayCodec (or any codec that can tell exact encoded byte sizes), directly copy to target ByteBuf instead of creating a temporary single-use copy first

Have added benchmarks (results in comments)
 
Refer #2610 

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes. (Already existed, added benchmark tests)