### PR TITLE
CI/CD quickstart

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,56 @@
+---
+
+name: CI / CD Pipeline
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+    branches:
+      - master
+      - '[0-9].*'
+  pull_request:
+    branches:
+      - master
+      - '[0-9].*'
+  schedule:
+    - cron: '0 1 * * *' # nightly build
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Set Java up n the runner
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Install missing dependencies to container
+        run: |
+          sudo apt update
+          sudo apt install -y stunnel make git gcc maven
+      - name: Maven offline
+        run: |
+          mvn -q dependency:go-offline
+      - name: Clean environment
+        run: |
+          make cleanup
+        env:
+          JVM_OPTS: -Xmx3200m
+          TERM: dumb
+      - name: Run tests
+        run: |
+          make test-coverage
+        env:
+          JVM_OPTS: -Xmx3200m
+          TERM: dumb
+      - name: Codecov
+        run: |
+          bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -923,7 +923,7 @@
                 </os>
             </activation>
             <properties>
-                <os.detected.classifier>linux-aarch64-fedora</os.detected.classifier>
+                <os.detected.classifier>linux-aarch_64-fedora</os.detected.classifier>
             </properties>
         </profile>
 


### PR DESCRIPTION
Utilizing the Github [actions](https://github.com/features/actions) to implement a simple pipeline

Initiated nightly or when there is a push / pull request, it consists of these steps:
1. Checkout the repo
2. Set the container environment 
3. Call "make clean"
4. Call "make test-coverage"

This first implementation heavily relies on the Makefile as a means to automate the process.
It also builds and deploys the Redis instances each time we run the pipeline.

The key disadvantages a future improvement might want to address are:
- stability - typically client tests are run against a stable release of the server to avoid running into issues with the server itself and not the client code
- performance - obviously even though the run is fast is executes some steps unnecessarily (if we are able to use a custom Docker image for example we would not have to go through step 2 at all)
- the "continuous deployment" part of CI/CD is missing, since we do not actually deploy a snapshot to Maven central

The purpose of this initial implementation is to serve as a stepping stone that we can then improve and in the same time guarantee that any incoming changes are not breaking the build integrity or degrading the test coverage.

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.