### PR TITLE
Use epoll over io_uring channel for Unix Domain Sockets

### DIFF
--- a/src/main/java/io/lettuce/core/resource/Transports.java
+++ b/src/main/java/io/lettuce/core/resource/Transports.java
@@ -74,7 +74,7 @@ public class Transports {
     public static class NativeTransports {
 
         static EventLoopResources RESOURCES = KqueueProvider.isAvailable() ? KqueueProvider.getResources()
-                : IOUringProvider.isAvailable() ? IOUringProvider.getResources() : EpollProvider.getResources();
+                : EpollProvider.isAvailable() ? EpollProvider.getResources() : IOUringProvider.getResources();
 
         /**
          * @return {@code true} if a native transport is available.


### PR DESCRIPTION

fix for the issue #2790

the current implementation uses io_uring as preferred.
the change contains switch of precedence to use  epoll over io_uring.
I did some reading on the performance comparisons of io_uring and epoll; 
io_uring is considered faster than epoll in some cases and not in others. -> https://github.com/axboe/liburing/issues/536

Since we are changing default behavior when both of them are available, there will be some performance change for clients that have both in runtime. 
i cant evaluate exactly how big the impact is and/or how many client will be impacted. 
happy to hear any comments. 

- [X] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

